### PR TITLE
CI: remove unneeded rpms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,7 @@ jobs:
                     yum -y install bison
                     yum -y install git
                     yum -y install wget
-                    yum -y install rh-python38
                     yum -y install python3-pip
-                    yum -y install zlib-devel
                     yum -y install bzip2
                     yum -y install glibc-static
                     yum -y install libstdc++-static


### PR DESCRIPTION
These two seem not to be needed.  I'm guessing that `python3-pip` has some version of `python3` as a dependency already.