### PR TITLE
Witnesses: Simplify invalidity witnesses

### DIFF
--- a/src/ChcGraph.h
+++ b/src/ChcGraph.h
@@ -138,8 +138,7 @@ public:
 
     std::vector<SymRef> getVertices() const;
 
-    Logic & getLogic() { return logic; }
-    Logic const & getLogic() const { return logic; }
+    Logic & getLogic() const { return logic; }
     void toDot(std::ostream& out, bool full = false) const;
     ChcDirectedGraph reverse() const;
     DirectedEdge reverseEdge(DirectedEdge const & edge, TermUtils & utils) const;
@@ -209,6 +208,16 @@ class ChcDirectedHyperGraph {
     EId freshId() const { return EId{freeId++}; }
 
 public:
+    class VertexInstances {
+        std::map<EId, std::vector<unsigned>> instanceCounter;
+    public:
+        explicit VertexInstances(ChcDirectedHyperGraph const & graph);
+
+        unsigned getInstanceNumber(EId eid, unsigned sourceIndex) const {
+            return instanceCounter.at(eid)[sourceIndex];
+        }
+    };
+
     ChcDirectedHyperGraph(std::vector<DirectedHyperEdge> edges,
                           NonlinearCanonicalPredicateRepresentation predicates,
                           Logic & logic) :
@@ -222,8 +231,8 @@ public:
     }
 
     std::vector<SymRef> getVertices() const;
-    Logic & getLogic() { return logic; }
-    Logic const & getLogic() const { return logic; }
+    std::vector<DirectedHyperEdge> getEdges() const;
+    Logic & getLogic() const { return logic; }
     NonlinearCanonicalPredicateRepresentation const & predicateRepresentation() const { return predicates; }
     bool isNormalGraph() const;
     std::unique_ptr<ChcDirectedGraph> toNormalGraph() const;

--- a/src/TermUtils.h
+++ b/src/TermUtils.h
@@ -147,13 +147,14 @@ public:
 
     PTRef conjoin (PTRef what, PTRef to);
 
-    void insertVarPairsFromPredicates(PTRef domain, PTRef codomain, substitutions_map & subst) const {
+    void mapFromPredicate(PTRef domain, PTRef codomain, substitutions_map & subst) const {
         assert(isUPOrConstant(domain) and isUPOrConstant(codomain));
+        assert(logic.getSymName(domain) == logic.getSymName(codomain));
         auto domainVars = predicateArgsInOrder(domain);
         auto codomainVars = predicateArgsInOrder(codomain);
         assert(domainVars.size() == codomainVars.size());
         for (std::size_t i = 0; i < domainVars.size(); ++i) {
-            assert(logic.isVar(domainVars[i]) and logic.isVar(codomainVars[i]));
+            assert(logic.isVar(domainVars[i]));
             subst.insert({domainVars[i], codomainVars[i]});
         }
     }

--- a/src/Validator.cc
+++ b/src/Validator.cc
@@ -6,296 +6,126 @@
 
 #include "Validator.h"
 
-Validator::Result Validator::validate(const ChcSystem & system, const SystemVerificationResult & result) {
+Validator::Result Validator::validate(ChcDirectedHyperGraph const & graph, VerificationResult const & result) {
     switch (result.getAnswer()) {
-        case VerificationResult::SAFE:
-            return validateValidityWitness(system, result.getValidityWitness());
-            break;
-            case VerificationResult::UNSAFE:
-                return validateInvalidityWitness(system, result.getInvalidityWitness());
+        case VerificationAnswer::SAFE:
+            return validateValidityWitness(graph, result.getValidityWitness());
+        case VerificationAnswer::UNSAFE:
+                return validateInvalidityWitness(graph, result.getInvalidityWitness());
         default:
             return Validator::Result::NOT_VALIDATED;
-    }
-    if (result.getAnswer() == VerificationResult::SAFE) {
-
     }
     return Validator::Result::NOT_VALIDATED;
 }
 
-Validator::Result Validator::validateValidityWitness(const ChcDirectedGraph & graph, const ValidityWitness & witness) {
-    auto definitions = witness.getDefinitions();
-    definitions.insert({logic.getTerm_true(), logic.getTerm_true()});
-    definitions.insert({logic.getTerm_false(), logic.getTerm_false()});
-    auto adjacencyList = AdjacencyListsGraphRepresentation::from(graph);
-    Validator::Result result = Result::VALIDATED;
-    graph.forEachEdge([&](DirectedEdge const & edge) {
-        auto from = edge.from;
-        auto to = edge.to;
-        PTRef fla = edge.fla.fla;
-        PTRef fromPredicate = graph.getStateVersion(from);
-        PTRef toPredicate = graph.getStateVersion(to);
-        if (definitions.count(fromPredicate) == 0 || definitions.count(toPredicate) == 0) {
-            result = Validator::Result::NOT_VALIDATED;
-            return;
-        }
-        PTRef fromInterpreted = definitions.at(fromPredicate);
-        PTRef toInterpreted = TimeMachine(logic).sendFlaThroughTime(definitions.at(toPredicate), 1);
-        //  test validity of implication 'fromInterpreted and fla => toInterpreted'
-        // equivalently test satisfiability of 'fromInterepted and fla and not(toInterpreted)'
-        PTRef query = logic.mkAnd({fromInterpreted, fla, logic.mkNot(toInterpreted)});
-        SMTConfig config;
-        MainSolver solver(logic, config, "validator");
-        solver.insertFormula(query);
-        auto res = solver.check();
-        if (res != s_False) {
-            result = Validator::Result::NOT_VALIDATED;
-        }
-    });
-    return result;
-}
-
-Validator::Result Validator::validateValidityWitness(const ChcSystem & system, const ValidityWitness & witness) {
+Validator::Result Validator::validateValidityWitness(ChcDirectedHyperGraph const & graph, ValidityWitness const & witness) {
     auto definitions = witness.getDefinitions();
     if (definitions.find(logic.getTerm_false()) == definitions.end()) {
         definitions.insert({logic.getTerm_false(), logic.getTerm_false()});
+        definitions.insert({logic.getTerm_true(), logic.getTerm_true()});
     }
     TermUtils utils(logic);
-    for (auto const & clause : system.getClauses()) {
-        // build antecedent
-        auto bodyPredicates = clause.body.uninterpretedPart;
-        vec<PTRef> antecedentArgs;
-        for (auto predicate : bodyPredicates) {
-            PTRef predicateTerm = predicate.predicate;
-            SymRef predicateSymbol = logic.getSymRef(predicateTerm);
-            auto it = std::find_if(definitions.begin(), definitions.end(),
-                                   [this, predicateSymbol](decltype(definitions)::value_type const & entry) {
-               return logic.getSymRef(entry.first) == predicateSymbol;
-            });
-            if (it == definitions.end()) {
-                std::cerr << ";Missing definition of a predicate " << logic.printTerm(predicateTerm) << std::endl;
-                return Validator::Result::NOT_VALIDATED;
-            }
-            // we need to substitute real arguments in the definition of the predicate
-            PTRef definitionTemplate = it->second;
-            // build the substitution map
-            std::unordered_map<PTRef, PTRef, PTRefHash> subst;
-            utils.insertVarPairsFromPredicates(it->first, predicateTerm, subst);
-            PTRef interpretedDefinition = utils.varSubstitute(definitionTemplate, subst);
-            antecedentArgs.push(interpretedDefinition);
-        }
-        antecedentArgs.push(clause.body.interpretedPart.fla);
-        PTRef antecedent = logic.mkAnd(antecedentArgs);
-        // build consequent
-        PTRef predicateTerm = clause.head.predicate.predicate;
-        SymRef predicateSymbol = logic.getSymRef(predicateTerm);
+    ChcDirectedHyperGraph::VertexInstances vertexInstances(graph);
+    // get correct interpretation for each node
+    auto getInterpretation = [&](PTRef nodePredicate) -> PTRef {
+        auto symbol = logic.getSymRef(nodePredicate);
         auto it = std::find_if(definitions.begin(), definitions.end(),
-                               [this, predicateSymbol](decltype(definitions)::value_type const & entry) {
-                                   return logic.getSymRef(entry.first) == predicateSymbol;
+                               [this,symbol](auto const & entry) {
+                                   return logic.getSymRef(entry.first) == symbol;
                                });
         if (it == definitions.end()) {
-            std::cerr << ";Missing definition of a predicate " << logic.printTerm(predicateTerm) << std::endl;
-            return Validator::Result::NOT_VALIDATED;
+            std::cerr << ";Missing definition of a predicate " << logic.printSym(symbol) << std::endl;
+            return PTRef_Undef;
         }
         // we need to substitute real arguments in the definition of the predicate
         PTRef definitionTemplate = it->second;
         // build the substitution map
-        auto formalArgs = utils.predicateArgsInOrder(it->first);
-        auto realArgs = utils.predicateArgsInOrder(predicateTerm);
-        assert(formalArgs.size() == realArgs.size());
         std::unordered_map<PTRef, PTRef, PTRefHash> subst;
-        for (std::size_t i = 0; i < formalArgs.size(); ++i) {
-            subst.insert({formalArgs[i], realArgs[i]});
-        }
-        PTRef consequent = utils.varSubstitute(definitionTemplate, subst);
-        // check the validity of implication
-        PTRef query = logic.mkAnd(antecedent, logic.mkNot(consequent));
-        SMTConfig config;
-        MainSolver solver(logic, config, "validator");
-        solver.insertFormula(query);
-        auto res = solver.check();
-        if (res != s_False) {
-
-            std::cerr << ";Clause ";
-            ChcPrinter(logic, std::cerr).print(clause);
-            std::cerr << " not valid" << std::endl;
-            return Validator::Result::NOT_VALIDATED;
-        }
-    }
-    return Validator::Result::VALIDATED;
-}
-
-
-namespace{
-using Derivation = SystemInvalidityWitness::Derivation;
-using DerivationStep = Derivation::DerivationStep;
-bool isCorrectlyDerived(DerivationStep const & step, Derivation const & derivation, Logic & logic) {
-    assert(step.type == DerivationStep::StepType::DERIVED);
-    // Head of this step's clause should be the head of nucleus' head
-    DerivationStep const & nucleus = derivation[step.nucleus];
-    if (nucleus.clause.head != step.clause.head) { return false; }
-    // uninterpreted predicates of nucleus must be the heads of satellites
-    std::vector<UninterpretedPredicate> satellites;
-    for (auto index : step.satellites) {
-        satellites.push_back(derivation[index].clause.head.predicate);
-    }
-    // there must be exact match between satellites and UPs in body of nucleus
-    if (satellites.size() != nucleus.clause.body.uninterpretedPart.size()) { return false; }
-    for (auto const & bodyUP : nucleus.clause.body.uninterpretedPart) {
-        if (std::find(satellites.begin(), satellites.end(), bodyUP) == satellites.end()) { return false; }
-    }
-    for (auto const & satellite : satellites) {
-        if (std::find(nucleus.clause.body.uninterpretedPart.begin(), nucleus.clause.body.uninterpretedPart.end(), satellite) == nucleus.clause.body.uninterpretedPart.end()) { return false; }
-    }
-    // uninterpreted part of derived should be the collection of uninterpreted parts of satellites (in our case, actually empty)
-    std::vector<UninterpretedPredicate> satellitesUninterpretedBodies;
-    for (auto index : step.satellites) {
-        for (auto const & UP : derivation[index].clause.body.uninterpretedPart) {
-            satellitesUninterpretedBodies.push_back(UP);
-        }
-    }
-    if (satellitesUninterpretedBodies.size() != step.clause.body.uninterpretedPart.size()) { return false; }
-    for (std::size_t i = 0; i < satellitesUninterpretedBodies.size(); ++i) {
-        if (satellitesUninterpretedBodies[i] != step.clause.body.uninterpretedPart[i]) { return false; }
-    }
-
-    // interpreted part must match
-    vec<PTRef> interpretedParts;
-    for (auto index : step.satellites) {
-        interpretedParts.push(derivation[index].clause.body.interpretedPart.fla);
-    }
-    interpretedParts.push(nucleus.clause.body.interpretedPart.fla);
-    return logic.mkAnd(interpretedParts) == step.clause.body.interpretedPart.fla;
-}
-}
-
-Validator::Result
-Validator::validateInvalidityWitness(const ChcSystem & system, const SystemInvalidityWitness & witness) {
-    auto & derivation = witness.getDerivation();
-    auto & model = witness.getModel();
-    auto derivationSize = derivation.size();
-    if (derivationSize == 0) { return Result::NOT_VALIDATED; }
-    for (std::size_t i = 0; i < derivationSize; ++i) {
-        auto & step = derivation[i];
-        bool stepValidated = false;
-        switch (step.type) {
-            case decltype(step.type)::INPUT:
-                // validate input clause
-                stepValidated = isPresentInSystem(step.clause, system);
-                break;
-            case decltype(step.type)::DERIVED:
-                // validate derived clause
-                stepValidated = isCorrectlyDerived(step, derivation, logic);
-                break;
-            default:
-                assert(false);
-                return Validator::Result::NOT_VALIDATED;
-        }
-        if (not stepValidated) { return Validator::Result::NOT_VALIDATED; }
-    }
-    // check if the last clause is interpreted formula and model falsifies it
-    ChClause const & derived = derivation.last().clause;
-    bool hasOnlyInterpretedBody = [this](ChClause const & clause) {
-        auto const & uninterpreted = clause.body.uninterpretedPart;
-        return uninterpreted.empty() || (uninterpreted.size() == 1 && uninterpreted[0].predicate == logic.getTerm_true());
-    }(derived);
-    bool hasEmptyHead = derived.head.predicate.predicate == logic.getTerm_false();
-    if (not hasOnlyInterpretedBody || not hasEmptyHead) { return Validator::Result::NOT_VALIDATED; }
-    // Now we know it is of form '\phi \implies \bot' (in other words 'F => false')
-    // This is falsified if the interpreted part is satisfied
-    PTRef value = model.evaluate(derived.body.interpretedPart.fla);
-    if (value != logic.getTerm_true()) { return Validator::Result::NOT_VALIDATED; }
-    return Validator::Result::VALIDATED;
-}
-
-namespace {
-// return true if 'c1' is an instance of 'c2'
-bool isInstanceOf(const ChClause & c1, const ChClause & c2, Logic & logic) {
-    if (c1.body.uninterpretedPart.size() != c2.body.uninterpretedPart.size()) { return false; }
-    using UPPair = std::pair<UninterpretedPredicate, UninterpretedPredicate>;
-    std::vector<UPPair> upsToProcess;
-    upsToProcess.emplace_back(c1.head.predicate, c2.head.predicate);
-    std::transform(c1.body.uninterpretedPart.begin(), c1.body.uninterpretedPart.end(),
-                   c2.body.uninterpretedPart.begin(), std::back_inserter(upsToProcess),
-                   [](UninterpretedPredicate up1, UninterpretedPredicate up2) {
-       return std::make_pair(up1, up2);
-    });
-    auto hasSameSymbol = [&logic](UPPair const & pair) {
-        return logic.getSymRef(pair.first.predicate) == logic.getSymRef(pair.second.predicate);
+        utils.mapFromPredicate(it->first, nodePredicate, subst);
+        return utils.varSubstitute(definitionTemplate, subst);
     };
-    bool predicatesMatch = std::all_of(upsToProcess.begin(), upsToProcess.end(), hasSameSymbol);
-    if (not predicatesMatch) { return false; }
-    TimeMachine timeMachine(logic);
-    VersionManager versionManager(logic);
-    TermUtils utils(logic);
 
-    using subst_map = std::unordered_map<PTRef, PTRef, PTRefHash>;
-    subst_map subst; // substitution map from c2 -> c1
-    for (auto const & uppair : upsToProcess) {
-        utils.insertVarPairsFromPredicates(uppair.second.predicate, uppair.first.predicate, subst);
-    }
-    // c1 is a clause from path, c2 from normalized system
-    // variables from c1 stripped of their version need to match the base form of variables from c2
-    bool varsMatch = std::all_of(subst.begin(), subst.end(), [&](auto const & varPair){
-        PTRef versionedVar = varPair.second;
-        PTRef unversionedVar = timeMachine.getUnversioned(versionedVar);
-        PTRef taggedVar = varPair.first;
-        PTRef baseVar = versionManager.toBase(taggedVar);
-        return unversionedVar == baseVar;
-    });
-    if (not varsMatch) {
-        return false;
-    }
-    PTRef modified_c2 = utils.varSubstitute(c2.body.interpretedPart.fla, subst);
-    return c1.body.interpretedPart.fla == modified_c2;
-}
-
-ChClause toZeroStepVersion(Logic & logic, ChClause clause) {
-    std::optional<int> versionDiff {};
-    TimeMachine timeMachine(logic);
-    PTRef headPredicate = clause.head.predicate.predicate;
-    if (logic.getPterm(headPredicate).nargs() > 0) {
-        auto vars = TermUtils(logic).predicateArgsInOrder(headPredicate);
-        assert(not vars.empty());
-        auto version = timeMachine.getVersionNumber(vars[0]);
-        assert(std::all_of(vars.begin(), vars.end(), [version, &timeMachine](PTRef var) {
-            return timeMachine.getVersionNumber(var) == version;
-        }));
-        versionDiff = version - 1; // Version in head is version in body + 1
-    }
-    auto const & bodyPredicates = clause.body.uninterpretedPart;
-    if (not bodyPredicates.empty()) {
-        if (bodyPredicates.size() > 1) { throw ValidationException("Cannot validate InvalidityWitness for non-linear clauses yet!"); }
-        PTRef bodyPredicate = bodyPredicates[0].predicate;
-        if (logic.getPterm(bodyPredicate).nargs() > 0) {
-            auto vars = TermUtils(logic).predicateArgsInOrder(bodyPredicate);
-            assert(not vars.empty());
-            auto version = timeMachine.getVersionNumber(vars[0]);
-            assert(std::all_of(vars.begin(), vars.end(), [version, &timeMachine](PTRef var) {
-                return timeMachine.getVersionNumber(var) == version;
-            }));
-            if (versionDiff.has_value()) {
-                if (versionDiff.value() != version) { throw ValidationException("Unexpected version difference in head and body of a clause!"); }
-            } else {
-                versionDiff = version;
+    auto edges = graph.getEdges();
+    for (auto const & edge : edges) {
+        vec<PTRef> bodyComponents;
+        PTRef constraint = edge.fla.fla;
+        bodyComponents.push(constraint);
+        for (std::size_t i = 0; i < edge.from.size(); ++i) {
+            auto source = edge.from[i];
+            PTRef predicate = graph.getStateVersion(source, vertexInstances.getInstanceNumber(edge.id, i));
+            PTRef interpreted = getInterpretation(predicate);
+            if (interpreted == PTRef_Undef) { return Result::NOT_VALIDATED; }
+            bodyComponents.push(interpreted);
+        }
+        PTRef interpretedBody = logic.mkAnd(std::move(bodyComponents));
+        PTRef interpretedHead = getInterpretation(graph.getNextStateVersion(edge.to));
+        PTRef query = logic.mkAnd(interpretedBody, logic.mkNot(interpretedHead));
+        {
+            SMTConfig config;
+            MainSolver solver(logic, config, "validator");
+            solver.insertFormula(query);
+            auto res = solver.check();
+            if (res != s_False) {
+                std::cerr << ";Edge not validated!";
+                // TODO: print edge
+                return Validator::Result::NOT_VALIDATED;
             }
         }
     }
-    if (not versionDiff.has_value()) { throw ValidationException("Clause with empty head and body encountered?!"); }
-    auto timeSteps = -versionDiff.value();
-
-    clause.head.predicate.predicate = timeMachine.sendFlaThroughTime(headPredicate, timeSteps);
-    clause.body.interpretedPart.fla = timeMachine.sendFlaThroughTime(clause.body.interpretedPart.fla, timeSteps);
-    std::for_each(clause.body.uninterpretedPart.begin(), clause.body.uninterpretedPart.end(), [&timeMachine, timeSteps](auto & predicate) {
-        predicate.predicate = timeMachine.sendFlaThroughTime(predicate.predicate, timeSteps);
-    });
-    return clause;
-}
+    return Validator::Result::VALIDATED;
 }
 
-bool Validator::isPresentInSystem(const ChClause & clause, const ChcSystem & system) const {
-    ChClause zeroStepVersionClause = toZeroStepVersion(logic, clause);
-    for (auto const & systemClause : system.getClauses()) {
-        if (isInstanceOf(zeroStepVersionClause, systemClause, logic)) { return true; }
+
+Validator::Result validateStep(
+    std::size_t stepIndex,
+    InvalidityWitness::Derivation const & derivation,
+    ChcDirectedHyperGraph const & graph,
+    ChcDirectedHyperGraph::VertexInstances const & vertexInstances
+    ) {
+    Logic & logic = graph.getLogic();
+    auto const & step = derivation[stepIndex];
+    EId edge = step.clauseId;
+    TermUtils::substitutions_map subst;
+    TermUtils utils(logic);
+    auto fillVariables = [&](PTRef derivedFact, PTRef normalizedPredicate) {
+        assert(logic.getSymRef(derivedFact) == logic.getSymRef(normalizedPredicate));
+        auto const & term = logic.getPterm(derivedFact); (void) term;
+        assert(std::all_of(term.begin(), term.end(), [&](PTRef arg) { return logic.isConstant(arg); }));
+        utils.mapFromPredicate(normalizedPredicate, derivedFact, subst);
+    };
+    // get values for the variables from predicates
+    auto sourceNodes = graph.getSources(edge);
+    // remove TOP from sources
+    sourceNodes.erase(std::remove(sourceNodes.begin(), sourceNodes.end(), logic.getSym_true()), sourceNodes.end());
+    assert(sourceNodes.size() == step.premises.size());
+    for (std::size_t i = 0; i < sourceNodes.size(); ++i) {
+        auto source = sourceNodes[i];
+        auto const & premise = derivation[step.premises[i]];
+        fillVariables(premise.derivedFact, graph.getStateVersion(source, vertexInstances.getInstanceNumber(edge, i)));
     }
-    return false;
+    auto target = graph.getTarget(edge);
+    fillVariables(step.derivedFact, graph.getNextStateVersion(target));
+    PTRef constraintAfterSubstitution = utils.varSubstitute(graph.getEdgeLabel(edge), subst);
+    if (constraintAfterSubstitution == logic.getTerm_true()) { return Validator::Result::VALIDATED; }
+    if (constraintAfterSubstitution == logic.getTerm_false()) { return Validator::Result::NOT_VALIDATED; }
+    SMTConfig config;
+    MainSolver solver(logic, config, "validator");
+    solver.insertFormula(constraintAfterSubstitution);
+    auto res = solver.check();
+    if (res == s_True) { return Validator::Result::VALIDATED; }
+    return Validator::Result::NOT_VALIDATED;
 }
+
+Validator::Result
+Validator::validateInvalidityWitness(ChcDirectedHyperGraph const & graph, InvalidityWitness const & witness) {
+    auto const & derivation = witness.getDerivation();
+    auto derivationSize = derivation.size();
+    if (derivationSize == 0) { return Result::NOT_VALIDATED; }
+    ChcDirectedHyperGraph::VertexInstances vertexInstances(graph);
+    for (std::size_t i = 0; i < derivationSize; ++i) {
+        auto result = validateStep(i, derivation, graph, vertexInstances);
+        if (result == Validator::Result::NOT_VALIDATED) { return result; }
+    }
+    return Validator::Result::VALIDATED;
+}
+

--- a/src/Validator.h
+++ b/src/Validator.h
@@ -23,14 +23,11 @@ public:
     Validator(Logic & logic) : logic(logic) {}
 
     enum class Result {VALIDATED, NOT_VALIDATED};
-    Result validate(ChcSystem const & system, SystemVerificationResult const & result);
+    Result validate(ChcDirectedHyperGraph const & system, VerificationResult const & result);
 
 private:
-    Result validateValidityWitness(ChcDirectedGraph const & graph, ValidityWitness const & witness);
-    Result validateValidityWitness(ChcSystem const & system, ValidityWitness const & witness);
-    Result validateInvalidityWitness(ChcSystem const & system, SystemInvalidityWitness const & witness);
-
-    bool isPresentInSystem(ChClause const & clause, ChcSystem const & system) const;
+    Result validateValidityWitness(ChcDirectedHyperGraph const & graph, ValidityWitness const & witness);
+    Result validateInvalidityWitness(ChcDirectedHyperGraph const & graph, InvalidityWitness const & witness);
 };
 
 

--- a/src/Witnesses.cc
+++ b/src/Witnesses.cc
@@ -8,14 +8,44 @@
 
 #include "TransformationUtils.h"
 
-SystemInvalidityWitness graphToSystemInvalidityWitness(InvalidityWitness const & witness, ChcDirectedGraph & graph) {
-    using Derivation = SystemInvalidityWitness::Derivation;
+void VerificationResult::printWitness(std::ostream & out, Logic & logic) const {
+    switch (answer) {
+        case VerificationAnswer::SAFE: {
+            TermUtils utils(logic);
+            validityWitness.print(out, logic);
+            return;
+        }
+        case VerificationAnswer::UNSAFE: {
+            invalidityWitness.print(out, logic);
+            return;
+        }
+        default:
+            return;
+    }
+}
+
+InvalidityWitness InvalidityWitness::fromErrorPath(ErrorPath const & errorPath, ChcDirectedGraph const & graph) {
+    using Derivation = InvalidityWitness::Derivation;
     Logic & logic = graph.getLogic();
     Derivation derivation;
     using DerivationStep = Derivation::DerivationStep;
-    auto const & path = witness.getErrorPath();
-    if (path.isEmpty()) { return SystemInvalidityWitness(); }
+    auto const & path = errorPath;
+    if (path.isEmpty()) { return InvalidityWitness(); }
     auto edgeIds = path.getEdges();
+    // Compute model for the error path
+    auto model = [&]() {
+        SMTConfig config;
+        MainSolver solver(logic, config, "path_solver");
+        for (std::size_t i = 0; i < edgeIds.size(); ++i) {
+            PTRef fla = graph.getEdgeLabel(edgeIds[i]);
+            fla = TimeMachine(logic).sendFlaThroughTime(fla, i);
+            solver.insertFormula(fla);
+        }
+        auto res = solver.check();
+        if (res != s_True) { throw std::logic_error("Error in computing model for the error path"); }
+        return solver.getModel();
+    }();
+
     struct UPHelper{
         int counter = 0;
         ChcDirectedGraph const & graph;
@@ -28,96 +58,63 @@ SystemInvalidityWitness graphToSystemInvalidityWitness(InvalidityWitness const &
 
         UPHelper(ChcDirectedGraph const & graph, Logic & logic) : graph(graph), timeMachine(logic) {}
     };
+    assert(graph.getSource(edgeIds[0]) == logic.getSym_true());
     std::vector<SymRef> vertices;
     std::transform(edgeIds.begin(), edgeIds.end(), std::back_inserter(vertices),
                    [&graph](EId eid) { return graph.getSource(eid); });
     vertices.push_back(graph.getTarget(edgeIds.back()));
     std::vector<PTRef> vertexPredicates;
     std::transform(vertices.begin(), vertices.end(), std::back_inserter(vertexPredicates), UPHelper(graph, logic));
+
+    auto instantiate = [&](PTRef predicate) {
+        TermUtils utils(logic);
+        auto vars = utils.predicateArgsInOrder(predicate);
+        TermUtils::substitutions_map subst;
+        for (PTRef var : vars) {
+            subst.insert({var, model->evaluate(var)});
+        }
+        return utils.varSubstitute(predicate, subst);
+    };
+
+    // Drop the first predicate, which is TOP
+    vertexPredicates.erase(vertexPredicates.begin());
+
+    assert(vertexPredicates.size() == edgeIds.size());
     std::size_t stepCounter = 0;
     for (std::size_t i = 0; i < edgeIds.size(); ++i) {
-        std::vector<UninterpretedPredicate> uninterpretedPart;
-        if (vertexPredicates[i] != logic.getTerm_true()) { uninterpretedPart.push_back(UninterpretedPredicate{.predicate = vertexPredicates[i]}); }
-        PTRef edgeFla = graph.getEdgeLabel(edgeIds[i]);
-        PTRef interpretedPart = TimeMachine(logic).sendFlaThroughTime(edgeFla, i);
+        auto id = edgeIds[i];
         DerivationStep step;
         step.index = stepCounter++;
-        step.type = DerivationStep::StepType::INPUT;
-        step.clause = ChClause{ChcHead{UninterpretedPredicate{vertexPredicates[i + 1]}},
-                               ChcBody{{interpretedPart}, std::move(uninterpretedPart)}
-        };
+        step.clauseId = id;
+        step.premises = i == 0 ? std::vector<size_t>{} : std::vector<size_t>{i - 1};
+        step.derivedFact = instantiate(vertexPredicates[i]);
         derivation.addDerivationStep(std::move(step));
     }
-    auto hasOnlyInterpretedBody = [&logic](ChClause const & clause) {
-        auto const & uninterpreted = clause.body.uninterpretedPart;
-        return uninterpreted.empty() || (uninterpreted.size() == 1 && uninterpreted[0].predicate == logic.getTerm_true());
-    };
-    assert(hasOnlyInterpretedBody(derivation[0].clause));
-    if (not hasOnlyInterpretedBody(derivation[0].clause)) {
-        throw std::logic_error("Unexpected error in building the invalidity witness");
-    }
-    std::size_t previousDerivation = 0;
-    for (std::size_t i = 1; i < edgeIds.size(); ++i) {
-        DerivationStep step;
-        step.index = stepCounter++;
-        step.type = decltype(step.type)::DERIVED;
-        step.nucleus = i;
-        step.satellites = {previousDerivation};
-        DerivationStep const & satellite = derivation[previousDerivation];
-        DerivationStep const & nucleus = derivation[step.nucleus];
-        (void)nucleus;
-        assert(hasOnlyInterpretedBody(satellite.clause));
-        assert(nucleus.clause.body.uninterpretedPart.size() == 1);
-        assert(satellite.clause.head.predicate == nucleus.clause.body.uninterpretedPart[0]);
-        step.clause.head = derivation[i].clause.head;
-        step.clause.body = ChcBody{{logic.mkAnd(satellite.clause.body.interpretedPart.fla, derivation[i].clause.body.interpretedPart.fla)},
-            {satellite.clause.body.uninterpretedPart}
-        };
-        previousDerivation = step.index;
-        derivation.addDerivationStep(std::move(step));
-    }
-    auto const & derivedClause = derivation.last().clause;
-    SystemInvalidityWitness sysWitness;
-    // build the model
-    if (derivedClause.head.predicate.predicate != logic.getTerm_false() || not(hasOnlyInterpretedBody(derivedClause))) {
-        // error in derivation, no valid witness
-        throw std::logic_error("Error in computing the invalidity witness");
-    }
-    PTRef antecedent = derivedClause.body.interpretedPart.fla;
-    {
-        SMTConfig config;
-        MainSolver solver(logic, config, "CEX computer");
-        solver.insertFormula(antecedent);
-        auto res = solver.check();
-        if (res != s_True) { throw std::logic_error("Error in computing the invalidity witness"); }
-        auto model = solver.getModel();
-        assert(model->evaluate(antecedent) == logic.getTerm_true());
-        sysWitness.setModel(WitnessModel(std::move(model)));
-    }
-    sysWitness.setDerivation(std::move(derivation));
-    return sysWitness;
+
+    InvalidityWitness witness;
+    witness.setDerivation(std::move(derivation));
+    return witness;
 }
 
-void SystemInvalidityWitness::print(std::ostream & out, Logic & logic) const {
+InvalidityWitness InvalidityWitness::fromTransitionSystem(const ChcDirectedGraph & graph, std::size_t unrollings) {
+    return fromErrorPath(ErrorPath::fromTransitionSystem(graph, unrollings), graph);
+}
+
+void InvalidityWitness::print(std::ostream & out, Logic & logic) const {
     auto derivationSize = derivation.size();
     ChcPrinter printer(logic, out);
     for (std::size_t i = 0; i < derivationSize; ++i) {
         auto const & step = derivation[i];
-        out << i << ".\t";
-        printer.print(step.clause);
-        if (step.type == Derivation::DerivationStep::StepType::DERIVED) {
-            out << "From steps: " << step.nucleus;
-            for (auto index : step.satellites) {
+        out << i << ":\t";
+        out << logic.printTerm(step.derivedFact);
+        if (not step.premises.empty()) {
+            out << " -> ";
+            for (auto index : step.premises) {
                 out << ' ' << index;
             }
             out << '\n';
         }
         out << '\n';
-    }
-    out << "\nWith model:\n";
-    auto vars = TermUtils(logic).getVars(derivation.last().clause.body.interpretedPart.fla);
-    for (auto var : vars) {
-        out << logic.printTerm(var) << " := " << logic.printTerm(model.evaluate(var)) << '\n';
     }
     out << std::endl;
 }
@@ -136,7 +133,7 @@ void ValidityWitness::print(std::ostream & out, Logic & logic) const {
     }
 }
 
-InvalidityWitness InvalidityWitness::fromTransitionSystem(const ChcDirectedGraph & graph, std::size_t unrollings) {
+ErrorPath ErrorPath::fromTransitionSystem(const ChcDirectedGraph & graph, std::size_t unrollings) {
     if (not isTransitionSystem(graph)) { return {}; }
     auto adjacencyList = AdjacencyListsGraphRepresentation::from(graph);
     auto vertices = graph.getVertices();
@@ -152,14 +149,10 @@ InvalidityWitness InvalidityWitness::fromTransitionSystem(const ChcDirectedGraph
     EId loopingEdge = *it;
     EId startEdge = adjacencyList.getOutgoingEdgesFor(graph.getEntry())[0];
     EId finalEdge = adjacencyList.getIncomingEdgesFor(graph.getExit())[0];
-    InvalidityWitness witness;
-    InvalidityWitness::ErrorPath path;
     std::vector<EId> pathEdges(unrollings, loopingEdge);
     pathEdges.push_back(finalEdge);
     pathEdges.insert(pathEdges.begin(), startEdge);
-    path.setPath(std::move(pathEdges));
-    witness.setErrorPath(std::move(path));
-    return witness;
+    return ErrorPath(std::move(pathEdges));
 }
 
 ValidityWitness

--- a/src/engine/Bmc.cc
+++ b/src/engine/Bmc.cc
@@ -8,15 +8,15 @@
 #include "TermUtils.h"
 #include "TransformationUtils.h"
 
-GraphVerificationResult BMC::solve(ChcDirectedGraph const & system) {
+VerificationResult BMC::solve(ChcDirectedGraph const & system) {
     if (isTransitionSystem(system)) {
         auto ts = toTransitionSystem(system, logic);
         return solveTransitionSystem(*ts, system);
     }
-    return GraphVerificationResult(VerificationResult::UNKNOWN);
+    return VerificationResult(VerificationAnswer::UNKNOWN);
 }
 
-GraphVerificationResult BMC::solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph) {
+VerificationResult BMC::solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph) {
     std::size_t maxLoopUnrollings = std::numeric_limits<std::size_t>::max();
     PTRef init = system.getInit();
     PTRef query = system.getQuery();
@@ -29,7 +29,7 @@ GraphVerificationResult BMC::solveTransitionSystem(TransitionSystem const & syst
     { // Check for system with empty initial states
         auto res = solver.check();
         if (res == s_False) {
-            return GraphVerificationResult{VerificationResult::SAFE};
+            return VerificationResult{VerificationAnswer::SAFE};
         }
     }
 
@@ -44,7 +44,7 @@ GraphVerificationResult BMC::solveTransitionSystem(TransitionSystem const & syst
             if (verbosity > 0) {
                 std::cout << "; BMC: Bug found in depth: " << currentUnrolling << std::endl;
             }
-            return GraphVerificationResult(VerificationResult::UNSAFE, InvalidityWitness::fromTransitionSystem(graph, currentUnrolling));
+            return VerificationResult(VerificationAnswer::UNSAFE, InvalidityWitness::fromTransitionSystem(graph, currentUnrolling));
         }
         if (verbosity > 1) {
             std::cout << "; BMC: No path of length " << currentUnrolling << " found!" << std::endl;
@@ -54,5 +54,5 @@ GraphVerificationResult BMC::solveTransitionSystem(TransitionSystem const & syst
 //        std::cout << "Adding transition: " << logic.pp(versionedTransition) << std::endl;
         solver.insertFormula(versionedTransition);
     }
-    return GraphVerificationResult(VerificationResult::UNKNOWN);
+    return VerificationResult(VerificationAnswer::UNKNOWN);
 }

--- a/src/engine/Bmc.h
+++ b/src/engine/Bmc.h
@@ -22,18 +22,18 @@ public:
         }
     }
 
-    virtual GraphVerificationResult solve(ChcDirectedHyperGraph & graph) override {
+    virtual VerificationResult solve(ChcDirectedHyperGraph & graph) override {
         if (graph.isNormalGraph()) {
             auto normalGraph = graph.toNormalGraph();
             return solve(*normalGraph);
         }
-        return GraphVerificationResult(VerificationResult::UNKNOWN);
+        return VerificationResult(VerificationAnswer::UNKNOWN);
     }
 
-    GraphVerificationResult solve(ChcDirectedGraph const & system);
+    VerificationResult solve(ChcDirectedGraph const & system);
 
 private:
-    GraphVerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
+    VerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
 };
 
 

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -16,8 +16,8 @@
 
 class Engine {
 public:
-    virtual GraphVerificationResult solve(ChcDirectedHyperGraph &) {
-        return GraphVerificationResult(VerificationResult::UNKNOWN);
+    virtual VerificationResult solve(ChcDirectedHyperGraph &) {
+        return VerificationResult(VerificationAnswer::UNKNOWN);
     }
 
     virtual ~Engine() = default;

--- a/src/engine/Kind.h
+++ b/src/engine/Kind.h
@@ -28,12 +28,12 @@ public:
         }
     }
 
-    virtual GraphVerificationResult solve(ChcDirectedHyperGraph & graph) override;
+    virtual VerificationResult solve(ChcDirectedHyperGraph & graph) override;
 
-    GraphVerificationResult solve(ChcDirectedGraph const & system);
+    VerificationResult solve(ChcDirectedGraph const & system);
 
 private:
-    GraphVerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
+    VerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
 
     ValidityWitness witnessFromForwardInduction(ChcDirectedGraph const & graph,
                                                 TransitionSystem const & transitionSystem, unsigned long k) const;

--- a/src/engine/Lawi.h
+++ b/src/engine/Lawi.h
@@ -23,9 +23,9 @@ class Lawi : public Engine {
 public:
     Lawi(Logic & logic, Options const & options) : logic(logic), options(options) {}
 
-    GraphVerificationResult solve(ChcDirectedHyperGraph & system) override;
+    VerificationResult solve(ChcDirectedHyperGraph & system) override;
 
-    GraphVerificationResult solve(const ChcDirectedGraph & system);
+    VerificationResult solve(const ChcDirectedGraph & system);
 
 private:
 

--- a/src/engine/Spacer.h
+++ b/src/engine/Spacer.h
@@ -17,7 +17,7 @@ public:
 
     explicit Spacer(Logic & logic) : logic(logic) {}
 
-    [[nodiscard]] GraphVerificationResult solve(ChcDirectedHyperGraph & system) override;
+    [[nodiscard]] VerificationResult solve(ChcDirectedHyperGraph & system) override;
 };
 
 

--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -34,16 +34,16 @@ class TPAEngine : public Engine {
 public:
     TPAEngine(Logic & logic, Options options) : logic(logic), options(std::move(options)) {}
 
-    GraphVerificationResult solve(ChcDirectedHyperGraph & graph) override;
+    VerificationResult solve(ChcDirectedHyperGraph & graph) override;
 
     static const std::string TPA;
     static const std::string SPLIT_TPA;
 private:
-    GraphVerificationResult solve(const ChcDirectedGraph & system);
+    VerificationResult solve(const ChcDirectedGraph & system);
 
     std::unique_ptr<TPABase> mkSolver();
     
-    GraphVerificationResult solveTransitionSystemChain(ChcDirectedGraph const & graph);
+    VerificationResult solveTransitionSystemChain(ChcDirectedGraph const & graph);
 
     ValidityWitness computeValidityWitness(ChcDirectedGraph const & graph, TransitionSystem const & ts, PTRef inductiveInvariant) const;
 
@@ -111,11 +111,11 @@ public:
 
     virtual ~TPABase() = default;
 
-    virtual VerificationResult solveTransitionSystem(TransitionSystem & system);
+    virtual VerificationAnswer solveTransitionSystem(TransitionSystem & system);
 
     void resetTransitionSystem(TransitionSystem const & system);
 
-    VerificationResult solve();
+    VerificationAnswer solve();
 
     void resetInitialStates(PTRef);
 
@@ -132,7 +132,7 @@ public:
 
 protected:
 
-    virtual VerificationResult checkPower(unsigned short power) = 0;
+    virtual VerificationAnswer checkPower(unsigned short power) = 0;
 
     virtual void resetPowers() = 0;
 
@@ -216,7 +216,7 @@ public:
 private:
     void resetPowers() override;
 
-    VerificationResult checkPower(unsigned short power) override;
+    VerificationAnswer checkPower(unsigned short power) override;
     PTRef getPower(unsigned short power, TPAType relationType) const override;
     bool verifyPower(unsigned short power, TPAType relationType) const override;
 
@@ -252,7 +252,7 @@ public:
 private:
     void resetPowers() override;
 
-    VerificationResult checkPower(unsigned short power) override;
+    VerificationAnswer checkPower(unsigned short power) override;
 
     PTRef getPower(unsigned short power, TPAType relationType) const override;
     bool verifyPower(unsigned short power, TPAType relationType) const override;

--- a/src/transformers/NonLoopEliminator.cc
+++ b/src/transformers/NonLoopEliminator.cc
@@ -84,7 +84,7 @@ ValidityWitness NonLoopEliminator::BackTranslator::translate(ValidityWitness wit
             outgoingFormulas.push(logic.mkAnd(edge.fla.fla, logic.mkNot(targetDef)));
         }
         TermUtils::substitutions_map substitutionsMap;
-        utils.insertVarPairsFromPredicates(predicateRepresentation.getSourceTermFor(vertex), predicateRepresentation.getTargetTermFor(vertex), substitutionsMap);
+        utils.mapFromPredicate(predicateRepresentation.getSourceTermFor(vertex), predicateRepresentation.getTargetTermFor(vertex), substitutionsMap);
         PTRef incomingPart = logic.mkOr(std::move(incomingFormulas));
         PTRef outgoingPart = logic.mkOr(std::move(outgoingFormulas));
         outgoingPart = utils.varSubstitute(outgoingPart, substitutionsMap);

--- a/src/transformers/SimpleChainSummarizer.cc
+++ b/src/transformers/SimpleChainSummarizer.cc
@@ -83,7 +83,7 @@ ValidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(Vali
         for (auto const & edge : chain) {
             TermUtils::substitutions_map substitutionsMap;
             auto target = edge.to;
-            utils.insertVarPairsFromPredicates(predicateRepresentation.getTargetTermFor(target), predicateRepresentation.getSourceTermFor(target), substitutionsMap);
+            utils.mapFromPredicate(predicateRepresentation.getTargetTermFor(target), predicateRepresentation.getSourceTermFor(target), substitutionsMap);
             PTRef updatedLabel = utils.varSubstitute(edge.fla.fla, substitutionsMap);
             solver.insertFormula(updatedLabel);
         }

--- a/src/transformers/Transformer.h
+++ b/src/transformers/Transformer.h
@@ -18,13 +18,13 @@ public:
     virtual InvalidityWitness translate(InvalidityWitness witness) = 0;
     virtual ValidityWitness translate(ValidityWitness witness) = 0;
     virtual ~WitnessBackTranslator() = default;
-    GraphVerificationResult translate(GraphVerificationResult const & result) {
+    VerificationResult translate(VerificationResult const & result) {
         switch (result.getAnswer()) {
-            case VerificationResult::SAFE:
-                return GraphVerificationResult(result.getAnswer(), translate(result.getValidityWitness()));
-            case VerificationResult::UNSAFE:
-                return GraphVerificationResult(result.getAnswer(), translate(result.getInvalidityWitness()));
-            case VerificationResult::UNKNOWN:
+            case VerificationAnswer::SAFE:
+                return VerificationResult(result.getAnswer(), translate(result.getValidityWitness()));
+            case VerificationAnswer::UNSAFE:
+                return VerificationResult(result.getAnswer(), translate(result.getInvalidityWitness()));
+            case VerificationAnswer::UNKNOWN:
                 return result;
         }
         throw std::logic_error("Unreachable");

--- a/test/TestTemplate.h
+++ b/test/TestTemplate.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef GOLEM_TESTTEMPLATE_H
+#define GOLEM_TESTTEMPLATE_H
+
+#include "engine/Engine.h"
+#include "Validator.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+class EngineTest : public ::testing::Test {
+protected:
+    Options options;
+    ChcSystem system;
+    std::unique_ptr<ArithLogic> logic;
+
+    PTRef mkBoolVar(char const * const name) { return logic->mkBoolVar(name); }
+
+    SRef boolSort() const { return logic->getSort_bool(); }
+
+    SymRef mkPredicateSymbol(std::string const & name, vec<SRef> const & argSorts) {
+        SymRef sym = logic->declareFun(name, boolSort(), argSorts);
+        system.addUninterpretedPredicate(sym);
+        return sym;
+    }
+
+    PTRef instantiatePredicate(SymRef symbol, vec<PTRef> const & args) { return logic->mkUninterpFun(symbol, args); }
+
+    void solveSystem(std::vector<ChClause> const & clauses, Engine & engine, VerificationAnswer expectedAnswer, bool validate = true) {
+        for (auto const & clause : clauses) { system.addClause(clause); }
+
+        Logic & logic = *this->logic;
+        auto normalizedSystem = Normalizer(logic).normalize(system);
+        auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
+        auto res = engine.solve(*hypergraph);
+        auto answer = res.getAnswer();
+        ASSERT_EQ(answer, expectedAnswer);
+        if (validate) {
+            auto validationResult = Validator(logic).validate(*hypergraph, res);
+            ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
+        }
+    }
+};
+
+class LIAEngineTest : public EngineTest {
+protected:
+    PTRef zero;
+    PTRef one;
+    PTRef two;
+    PTRef x, xp;
+
+    LIAEngineTest() {
+        logic = std::make_unique<ArithLogic>(opensmt::Logic_t::QF_LIA);
+        zero = logic->getTerm_IntZero();
+        one = logic->getTerm_IntOne();
+        two = logic->mkIntConst(2);
+        x = mkIntVar("x");
+        xp = mkIntVar("xp");
+    }
+
+    PTRef mkIntVar(char const * const name) { return logic->mkIntVar(name); }
+
+    SRef intSort() const { return logic->getSort_int(); }
+};
+
+class LRAEngineTest : public EngineTest {
+protected:
+    PTRef zero;
+    PTRef one;
+    PTRef two;
+    PTRef x, xp;
+
+    LRAEngineTest() {
+        logic = std::make_unique<ArithLogic>(opensmt::Logic_t::QF_LRA);
+        zero = logic->getTerm_RealZero();
+        one = logic->getTerm_RealOne();
+        two = logic->mkRealConst(2);
+        x = mkRealVar("x");
+        xp = mkRealVar("xp");
+    }
+
+    PTRef mkRealVar(char const * const name) { return logic->mkRealVar(name); }
+
+    SRef realSort() const { return logic->getSort_real(); }
+};
+
+#endif //GOLEM_TESTTEMPLATE_H

--- a/test/test_BMC.cc
+++ b/test/test_BMC.cc
@@ -38,9 +38,8 @@ TEST(BMC_test, test_BMC_simple) {
     BMC bmc(logic, options);
     auto res = bmc.solve(*graph);
     auto answer = res.getAnswer();
-    ASSERT_EQ(answer, VerificationResult::UNSAFE);
+    ASSERT_EQ(answer, VerificationAnswer::UNSAFE);
     auto witness = res.getInvalidityWitness();
-    SystemVerificationResult systemResult (std::move(res), *hypergraph);
-    auto validationResult = Validator(logic).validate(*normalizedSystem.normalizedSystem, systemResult);
+    auto validationResult = Validator(logic).validate(*hypergraph, res);
     ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
 }

--- a/test/test_KIND.cc
+++ b/test/test_KIND.cc
@@ -4,64 +4,15 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <gtest/gtest.h>
+#include "TestTemplate.h"
 #include "engine/Kind.h"
-#include "Validator.h"
 
 
-class KindTest : public ::testing::Test {
-protected:
-    ArithLogic logic{opensmt::Logic_t::QF_LIA};
-    Options options;
-    ChcSystem system;
-    PTRef zero;
-    PTRef one;
-    PTRef two;
-    PTRef x, xp;
-
-    KindTest() {
-        zero = logic.getTerm_IntZero();
-        one = logic.getTerm_IntOne();
-        two = logic.mkIntConst(2);
-        x = mkIntVar("x");
-        xp = mkIntVar("xp");
-    }
-
-    PTRef mkIntVar(char const * const name) { return logic.mkIntVar(name); }
-
-    PTRef mkBoolVar(char const * const name) { return logic.mkBoolVar(name); }
-
-    SRef boolSort() const { return logic.getSort_bool(); }
-
-    SRef intSort() const { return logic.getSort_int(); }
-
-    SymRef mkPredicateSymbol(std::string const & name, vec<SRef> const & argSorts) {
-        SymRef sym = logic.declareFun(name, boolSort(), argSorts);
-        system.addUninterpretedPredicate(sym);
-        return sym;
-    }
-
-    PTRef instantiatePredicate(SymRef symbol, vec<PTRef> const & args) { return logic.mkUninterpFun(symbol, args); }
-
-    void solveSystem(std::vector<ChClause> const & clauses, Engine & engine, VerificationResult expectedResult, bool validate) {
-        for (auto const & clause : clauses) { system.addClause(clause); }
-
-        auto normalizedSystem = Normalizer(logic).normalize(system);
-        auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
-        auto res = engine.solve(*hypergraph);
-        auto answer = res.getAnswer();
-        ASSERT_EQ(answer, expectedResult);
-        if (validate) {
-            SystemVerificationResult systemResult(std::move(res), *hypergraph);
-            auto validationResult = Validator(logic).validate(*normalizedSystem.normalizedSystem, systemResult);
-            ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-        }
-    }
+class KindTest : public LIAEngineTest {
 };
 
 TEST_F(KindTest, test_KIND_simple_safe)
 {
-    Options options;
     options.addOption(Options::LOGIC, "QF_LIA");
     options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
@@ -73,23 +24,22 @@ TEST_F(KindTest, test_KIND_simple_safe)
     std::vector<ChClause> clauses{
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
         }};
-    Kind engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, true);
+    Kind engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(KindTest, test_KIND_moreInductionForward_safe)
 {
-    Options options;
     options.addOption(Options::LOGIC, "QF_LIA");
     options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
@@ -101,18 +51,18 @@ TEST_F(KindTest, test_KIND_moreInductionForward_safe)
     std::vector<ChClause> clauses{
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkIte(logic.mkEq(x, logic.mkIntConst(10)), zero, logic.mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkIte(logic->mkEq(x, logic->mkIntConst(10)), zero, logic->mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, logic.mkIntConst(15))}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, logic->mkIntConst(15))}, {UninterpretedPredicate{current}}}
         }};
-    Kind engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, true);
+    Kind engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(KindTest, test_KIND_moreInductionBackward_safe)
@@ -129,16 +79,16 @@ TEST_F(KindTest, test_KIND_moreInductionBackward_safe)
     std::vector<ChClause> clauses{
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkIte(logic.mkEq(x, logic.mkIntConst(5)), zero, logic.mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkIte(logic->mkEq(x, logic->mkIntConst(5)), zero, logic->mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, logic.mkIntConst(15))}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, logic->mkIntConst(15))}, {UninterpretedPredicate{current}}}
         }};
-    Kind engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, true);
+    Kind engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }

--- a/test/test_LAWI.cc
+++ b/test/test_LAWI.cc
@@ -4,247 +4,144 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <gtest/gtest.h>
+#include "TestTemplate.h"
 #include "engine/Lawi.h"
-#include "Validator.h"
 
-TEST(LAWI_test, test_LAWI_simple) {
-    ArithLogic logic{opensmt::Logic_t::QF_LRA};
-    Options options;
-    options.addOption(Options::LOGIC, "QF_LRA");
-    options.addOption(Options::COMPUTE_WITNESS, "true");
-    SymRef s1 = logic.declareFun("s1", logic.getSort_bool(), {logic.getSort_real()});
-    PTRef x = logic.mkRealVar("x");
-    PTRef xp = logic.mkRealVar("xp");
-    PTRef current = logic.mkUninterpFun(s1, {x});
-    PTRef next = logic.mkUninterpFun(s1, {xp});
-    ChcSystem system;
-    system.addUninterpretedPredicate(s1);
-    system.addClause(
-            ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.getTerm_RealZero())}, {}});
-    system.addClause(
-            ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.getTerm_RealOne()))}, {UninterpretedPredicate{current}}}
-    );
-    system.addClause(
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkLt(x, logic.getTerm_RealZero())}, {UninterpretedPredicate{current}}}
-    );
-    auto hypergraph = ChcGraphBuilder(logic).buildGraph(Normalizer(logic).normalize(system));
-    ASSERT_TRUE(hypergraph->isNormalGraph());
-    Lawi engine(logic, options);
-    auto res = engine.solve(*hypergraph);
-    auto answer = res.getAnswer();
-    ASSERT_EQ(answer, VerificationResult::SAFE);
-    auto witness = res.getValidityWitness();
-    SystemVerificationResult systemResult(std::move(res), *hypergraph);
-    auto validationResult = Validator(logic).validate(system, systemResult);
-    ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-}
-
-TEST(LAWI_test, test_LAWI_branch) {
-    ArithLogic logic{opensmt::Logic_t::QF_LRA};
-    Options options;
-    options.addOption(Options::LOGIC, "QF_LRA");
-    options.addOption(Options::COMPUTE_WITNESS, "true");
-    SymRef first = logic.declareFun("s1", logic.getSort_bool(), {logic.getSort_real(), logic.getSort_real()});
-    SymRef second = logic.declareFun("s2", logic.getSort_bool(), {logic.getSort_real(), logic.getSort_real()});
-    PTRef x = logic.mkRealVar("x");
-    PTRef xp = logic.mkRealVar("xp");
-    PTRef y = logic.mkRealVar("y");
-    PTRef yp = logic.mkRealVar("yp");
-    PTRef s1 = logic.mkUninterpFun(first, {x, y});
-    PTRef s1p = logic.mkUninterpFun(first, {xp, yp});
-    PTRef s2 = logic.mkUninterpFun(second, {x, y});
-    PTRef s2p = logic.mkUninterpFun(second, {xp, yp});
-    ChcSystem system;
-    system.addUninterpretedPredicate(first);
-    system.addUninterpretedPredicate(second);
-    system.addClause(
-        ChcHead{UninterpretedPredicate{s1p}},
-        ChcBody{{logic.mkEq(xp, logic.getTerm_RealZero())}, {}});
-    system.addClause(
-        ChcHead{UninterpretedPredicate{s1p}},
-        ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.getTerm_RealOne()))}, {UninterpretedPredicate{s1}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{s2}},
-        ChcBody{{logic.mkLt(y, logic.getTerm_RealZero())}, {UninterpretedPredicate{s1}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{s2}},
-        ChcBody{{logic.mkGeq(y, logic.getTerm_RealZero())}, {UninterpretedPredicate{s1}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{s2p}},
-        ChcBody{{
-            logic.mkAnd(
-                logic.mkEq(yp, logic.mkPlus(y, logic.getTerm_RealOne())),
-                logic.mkEq(xp, x)
-            )},
-            {UninterpretedPredicate{s2}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.mkLt(x, logic.getTerm_RealZero())}, {UninterpretedPredicate{s2}}}
-    );
-    auto normalizedSystem = Normalizer(logic).normalize(system);
-    auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
-    ASSERT_TRUE(hypergraph->isNormalGraph());
-    Lawi engine(logic, options);
-    auto res = engine.solve(*hypergraph);
-    auto answer = res.getAnswer();
-    ASSERT_EQ(answer, VerificationResult::SAFE);
-    SystemVerificationResult systemResult(std::move(res), *hypergraph);
-    systemResult.printWitness(std::cout, logic);
-    auto validationResult = Validator(logic).validate(system, systemResult);
-    ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-}
-
-TEST(LAWI_test, test_LAWI_unreachable_state) {
-    ArithLogic logic{opensmt::Logic_t::QF_LRA};
-    Options options;
-    options.addOption(Options::LOGIC, "QF_LRA");
-    options.addOption(Options::COMPUTE_WITNESS, "true");
-    SymRef s1 = logic.declareFun("s1", logic.getSort_bool(), {logic.getSort_real()});
-    SymRef bin = logic.declareFun("bin", logic.getSort_bool(), {logic.getSort_real()});
-    PTRef x = logic.mkRealVar("x");
-    PTRef xp = logic.mkRealVar("xp");
-    PTRef current = logic.mkUninterpFun(s1, {x});
-    PTRef next = logic.mkUninterpFun(s1, {xp});
-    PTRef binCurrent = logic.mkUninterpFun(bin, {x});
-    PTRef binNext = logic.mkUninterpFun(bin, {xp});
-    ChcSystem system;
-    system.addUninterpretedPredicate(s1);
-    system.addClause(
-        ChcHead{UninterpretedPredicate{next}},
-        ChcBody{{logic.mkEq(xp, logic.getTerm_RealZero())}, {}});
-    system.addClause(
-        ChcHead{UninterpretedPredicate{next}},
-        ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.getTerm_RealOne()))}, {UninterpretedPredicate{current}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.mkLt(x, logic.getTerm_RealZero())}, {UninterpretedPredicate{current}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{binNext}},
-        ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.getTerm_RealOne()))}, {UninterpretedPredicate{binCurrent}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{next}},
-        ChcBody{{
-            logic.mkAnd(
-                logic.mkEq(xp, x),
-                logic.mkLt(x, logic.getTerm_RealZero())
-            )},
-            {UninterpretedPredicate{binCurrent}}
-        }
-    );
-    auto hypergraph = ChcGraphBuilder(logic).buildGraph(Normalizer(logic).normalize(system));
-    ASSERT_TRUE(hypergraph->isNormalGraph());
-    Lawi engine(logic, options);
-    auto res = engine.solve(*hypergraph);
-    auto answer = res.getAnswer();
-    ASSERT_EQ(answer, VerificationResult::SAFE);
-    auto witness = res.getValidityWitness();
-    SystemVerificationResult systemResult(std::move(res), *hypergraph);
-    auto validationResult = Validator(logic).validate(system, systemResult);
-    systemResult.printWitness(std::cout, logic);
-    ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-}
-
-TEST(LAWI_test, test_LAWI_simple_unsafe) {
-    ArithLogic logic{opensmt::Logic_t::QF_LRA};
-    Options options;
-    options.addOption(Options::LOGIC, "QF_LRA");
-    options.addOption(Options::COMPUTE_WITNESS, "true");
-    SymRef s1 = logic.declareFun("s1", logic.getSort_bool(), {logic.getSort_real()});
-    PTRef x = logic.mkRealVar("x");
-    PTRef xp = logic.mkRealVar("xp");
-    PTRef current = logic.mkUninterpFun(s1, {x});
-    PTRef next = logic.mkUninterpFun(s1, {xp});
-    ChcSystem system;
-    system.addUninterpretedPredicate(s1);
-    system.addClause(
-        ChcHead{UninterpretedPredicate{next}},
-        ChcBody{{logic.mkEq(xp, logic.getTerm_RealZero())}, {}});
-    system.addClause(
-        ChcHead{UninterpretedPredicate{next}},
-        ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.getTerm_RealOne()))}, {UninterpretedPredicate{current}}}
-    );
-    system.addClause(
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.mkEq(x, logic.mkRealConst(FastRational(1)))}, {UninterpretedPredicate{current}}}
-    );
-    auto normalizedSystem = Normalizer(logic).normalize(system);
-    auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
-    ASSERT_TRUE(hypergraph->isNormalGraph());
-    Lawi engine(logic, options);
-    auto res = engine.solve(*hypergraph);
-    auto answer = res.getAnswer();
-    ASSERT_EQ(answer, VerificationResult::UNSAFE);
-
-    SystemVerificationResult systemResult(std::move(res), *hypergraph);
-    auto validationResult = Validator(logic).validate(*normalizedSystem.normalizedSystem, systemResult);
-    ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-}
-
-class LAWIIntTest : public ::testing::Test {
-protected:
-    ArithLogic logic{opensmt::Logic_t::QF_LIA};
-    Options options;
-    ChcSystem system;
-    PTRef zero;
-    PTRef one;
-    PTRef two;
-
-    LAWIIntTest() {
-        zero = logic.getTerm_IntZero();
-        one = logic.getTerm_IntOne();
-        two = logic.mkIntConst(2);
-    }
-
-    PTRef mkIntVar(char const * const name) { return logic.mkIntVar(name); }
-
-    PTRef mkBoolVar(char const * const name) { return logic.mkBoolVar(name); }
-
-    SRef boolSort() const { return logic.getSort_bool(); }
-
-    SRef intSort() const { return logic.getSort_int(); }
-
-    SymRef mkPredicateSymbol(std::string const & name, vec<SRef> const & argSorts) {
-        SymRef sym = logic.declareFun(name, boolSort(), argSorts);
-        system.addUninterpretedPredicate(sym);
-        return sym;
-    }
-
-    PTRef instantiatePredicate(SymRef symbol, vec<PTRef> const & args) { return logic.mkUninterpFun(symbol, args); }
-
-    auto getBasicEngine() { return std::make_unique<Lawi>(logic, options); }
-
-    void solveSystem(std::vector<ChClause> const & clauses, Engine & engine, VerificationResult expectedResult, bool validate) {
-        options.addOption(Options::COMPUTE_WITNESS, std::to_string(validate));
-
-        for (auto const & clause : clauses) { system.addClause(clause); }
-
-//        ChcPrinter(logic, std::cout).print(system);
-        auto normalizedSystem = Normalizer(logic).normalize(system);
-//        ChcPrinter(logic, std::cout).print(*normalizedSystem.normalizedSystem);
-        auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
-        ASSERT_TRUE(hypergraph->isNormalGraph());
-        auto res = engine.solve(*hypergraph);
-        auto answer = res.getAnswer();
-        ASSERT_EQ(answer, expectedResult);
-
-        SystemVerificationResult systemResult(std::move(res), *hypergraph);
-        auto validationResult = Validator(logic).validate(*normalizedSystem.normalizedSystem, systemResult);
-        ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-    }
+class LAWI_LRA_Test : public LRAEngineTest {
 };
 
-TEST_F(LAWIIntTest, test_LAWI_auxiliaryVar) {
+
+TEST_F(LAWI_LRA_Test, test_LAWI_simple) {
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {realSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{
+        { // x' = 0 => S1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        { // S1(x) and x' = x + 1 => S1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+        },
+        { // S1(x) and x < 0 => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+        }
+    };
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
+}
+
+TEST_F(LAWI_LRA_Test, test_LAWI_branch) {
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef first = mkPredicateSymbol("s1", {realSort(), realSort()});
+    SymRef second = mkPredicateSymbol("s2", {realSort(), realSort()});
+    PTRef y = mkRealVar("y");
+    PTRef yp = mkRealVar("yp");
+    PTRef s1 = instantiatePredicate(first, {x, y});
+    PTRef s1p = instantiatePredicate(first, {xp, yp});
+    PTRef s2 = instantiatePredicate(second, {x, y});
+    PTRef s2p = instantiatePredicate(second, {xp, yp});
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{s1p}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{s1p}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{s1}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{s2}},
+            ChcBody{{logic->mkLt(y, zero)}, {UninterpretedPredicate{s1}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{s2}},
+            ChcBody{{logic->mkGeq(y, zero)}, {UninterpretedPredicate{s1}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{s2p}},
+            ChcBody{{logic->mkAnd(logic->mkEq(yp, logic->mkPlus(y, one)), logic->mkEq(xp, x))}, {UninterpretedPredicate{s2}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{s2}}}
+        }
+    };
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
+}
+
+TEST_F(LAWI_LRA_Test, test_LAWI_unreachable_state) {
+    options.addOption(Options::LOGIC, "QF_LRA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {realSort()});
+    SymRef bin = mkPredicateSymbol("bin", {realSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next = instantiatePredicate(s1, {xp});
+    PTRef binCurrent = instantiatePredicate(bin, {x});
+    PTRef binNext = instantiatePredicate(bin, {xp});
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}    
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}    
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{binNext}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{binCurrent}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, x), logic->mkLt(x, zero))}, {UninterpretedPredicate{binCurrent}}}
+        }
+
+    };
+    
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
+}
+
+TEST_F(LAWI_LRA_Test, test_LAWI_simple_unsafe) {
+    options.addOption(Options::LOGIC, "QF_LRA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {realSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, one)}, {UninterpretedPredicate{current}}}
+        }
+    };
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE);
+}
+
+class LAWI_LIA_Test : public LIAEngineTest {
+};
+
+TEST_F(LAWI_LIA_Test, test_LAWI_auxiliaryVar) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s = mkPredicateSymbol("s", {intSort()});
     PTRef x = mkIntVar("x");
     PTRef xp = mkIntVar("xp");
@@ -253,20 +150,22 @@ TEST_F(LAWIIntTest, test_LAWI_auxiliaryVar) {
     PTRef next = instantiatePredicate(s, {xp});
     std::vector<ChClause> clauses{
         // x' = 0 => S(x')
-        {ChcHead{UninterpretedPredicate{next}}, ChcBody{{logic.mkEq(xp, zero)}, {}}},
+        {ChcHead{UninterpretedPredicate{next}}, ChcBody{{logic->mkEq(xp, zero)}, {}}},
         { // S(x) and x' = ite(b, x, x + 1) => S(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkIte(b, x, logic.mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkIte(b, x, logic->mkPlus(x, one)))}, {UninterpretedPredicate{current}}}
         },
         { // S(x) and x = 2 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, two)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, two)}, {UninterpretedPredicate{current}}}
         }
     };
-    solveSystem(clauses, *getBasicEngine(), VerificationResult::UNSAFE, true);
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
-TEST_F(LAWIIntTest, test_LAWI_auxiliaryVarElimination) {
+TEST_F(LAWI_LIA_Test, test_LAWI_auxiliaryVarElimination) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s = mkPredicateSymbol("s", {boolSort()});
     PTRef b = mkBoolVar("b");
     PTRef c = mkBoolVar("c");
@@ -277,18 +176,20 @@ TEST_F(LAWIIntTest, test_LAWI_auxiliaryVarElimination) {
     PTRef next = instantiatePredicate(s, {xp});
     std::vector<ChClause> clauses{
         // ~b and b = c and c = d and ~d = xp => S(xp)
-        {ChcHead{UninterpretedPredicate{next}}, ChcBody{{logic.mkAnd({
-            logic.mkEq(xp, logic.mkNot(d)), logic.mkEq(c,d), logic.mkEq(b,c), logic.mkNot(b)})}, {}
+        {ChcHead{UninterpretedPredicate{next}}, ChcBody{{logic->mkAnd({
+            logic->mkEq(xp, logic->mkNot(d)), logic->mkEq(c,d), logic->mkEq(b,c), logic->mkNot(b)})}, {}
         }},
         { // S(x) and x = false => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, logic.getTerm_false())}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, logic->getTerm_false())}, {UninterpretedPredicate{current}}}
         }
     };
-    solveSystem(clauses, *getBasicEngine(), VerificationResult::SAFE, true);
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
-TEST_F(LAWIIntTest, test_LAWI_auxiliaryVarElimination2) {
+TEST_F(LAWI_LIA_Test, test_LAWI_auxiliaryVarElimination2) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s = mkPredicateSymbol("s", {intSort()});
     PTRef x = mkIntVar("x");
     PTRef y = mkIntVar("y");
@@ -297,17 +198,19 @@ TEST_F(LAWIIntTest, test_LAWI_auxiliaryVarElimination2) {
     std::vector<ChClause> clauses{
         { //  z = 0 and x = 3y + z => S(x)
             ChcHead{UninterpretedPredicate{current}},
-            ChcBody{{logic.mkAnd(logic.mkEq(z, zero), logic.mkEq(x, logic.mkPlus(z, logic.mkTimes(y, logic.mkIntConst(3)))))},{}}
+            ChcBody{{logic->mkAnd(logic->mkEq(z, zero), logic->mkEq(x, logic->mkPlus(z, logic->mkTimes(y, logic->mkIntConst(3)))))},{}}
         },
         { // S(x) and x = 32 => false
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.mkEq(x, logic.mkIntConst(32))}, {UninterpretedPredicate{current}}}
+        ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+        ChcBody{{logic->mkEq(x, logic->mkIntConst(32))}, {UninterpretedPredicate{current}}}
         }
     };
-    solveSystem(clauses, *getBasicEngine(), VerificationResult::SAFE, true);
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
-TEST_F(LAWIIntTest, test_LAWI_bug) {
+TEST_F(LAWI_LIA_Test, test_LAWI_bug) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s = mkPredicateSymbol("s", {intSort(), intSort(), intSort()});
     PTRef x = mkIntVar("x");
     PTRef y = mkIntVar("y");
@@ -320,27 +223,28 @@ TEST_F(LAWIIntTest, test_LAWI_bug) {
     std::vector<ChClause> clauses{
         { //  S(x,y,z) and x = 1 and y = 1 and z = 0 and xp = 0 and yp = 0 and zp = 1 => S(xp,yp,zp)
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkAnd({
-                logic.mkEq(z, zero), logic.mkEq(x, one), logic.mkEq(y, one),
-                logic.mkEq(zp, one), logic.mkEq(xp, zero), logic.mkEq(yp, zero)
+            ChcBody{{logic->mkAnd({
+                logic->mkEq(z, zero), logic->mkEq(x, one), logic->mkEq(y, one),
+                logic->mkEq(zp, one), logic->mkEq(xp, zero), logic->mkEq(yp, zero)
             })},{UninterpretedPredicate{current}}}
         },
         { //  x = 0 and y = 0 and z = 0 => S(x,y,z)
             ChcHead{UninterpretedPredicate{current}},
-            ChcBody{{logic.mkAnd({logic.mkEq(z, zero), logic.mkEq(x, zero), logic.mkEq(y, zero)})},{}}
+            ChcBody{{logic->mkAnd({logic->mkEq(z, zero), logic->mkEq(x, zero), logic->mkEq(y, zero)})},{}}
         },
         { //  x = 1 and y = 1 and z = 0 => S(x,y,z)
             ChcHead{UninterpretedPredicate{current}},
-            ChcBody{{logic.mkAnd({logic.mkEq(z, zero), logic.mkEq(x, one), logic.mkEq(y, one)})},{}}
+            ChcBody{{logic->mkAnd({logic->mkEq(z, zero), logic->mkEq(x, one), logic->mkEq(y, one)})},{}}
         },
         { // S(x,y,z) and x = 0 and y = 0 and z = 1 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkAnd({logic.mkEq(x, zero), logic.mkEq(y, zero), logic.mkEq(z, one)})}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkAnd({logic->mkEq(x, zero), logic->mkEq(y, zero), logic->mkEq(z, one)})}, {UninterpretedPredicate{current}}}
         },
         { // S(x,y,z) and x = 1 and y = 1 and z = 1 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-                ChcBody{{logic.mkAnd({logic.mkEq(x, one), logic.mkEq(y, one), logic.mkEq(z, one)})}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+                ChcBody{{logic->mkAnd({logic->mkEq(x, one), logic->mkEq(y, one), logic->mkEq(z, one)})}, {UninterpretedPredicate{current}}}
         }
     };
-    solveSystem(clauses, *getBasicEngine(), VerificationResult::UNSAFE, true);
+    Lawi engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }

--- a/test/test_TPA.cc
+++ b/test/test_TPA.cc
@@ -4,87 +4,38 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include <gtest/gtest.h>
+#include "TestTemplate.h"
+
 #include "engine/TPA.h"
-#include "Validator.h"
 
-class TPATest : public ::testing::Test {
-protected:
-    ArithLogic logic{opensmt::Logic_t::QF_LIA};
-    Options options;
-    ChcSystem system;
-    PTRef zero;
-    PTRef one;
-    PTRef two;
-    PTRef x, xp;
-
-    TPATest() {
-        zero = logic.getTerm_IntZero();
-        one = logic.getTerm_IntOne();
-        two = logic.mkIntConst(2);
-        x = mkIntVar("x");
-        xp = mkIntVar("xp");
-    }
-
-    PTRef mkIntVar(char const * const name) { return logic.mkIntVar(name); }
-
-    PTRef mkBoolVar(char const * const name) { return logic.mkBoolVar(name); }
-
-    SRef boolSort() const { return logic.getSort_bool(); }
-
-    SRef intSort() const { return logic.getSort_int(); }
-
-    SymRef mkPredicateSymbol(std::string const & name, vec<SRef> const & argSorts) {
-        SymRef sym = logic.declareFun(name, boolSort(), argSorts);
-        system.addUninterpretedPredicate(sym);
-        return sym;
-    }
-
-    PTRef instantiatePredicate(SymRef symbol, vec<PTRef> const & args) { return logic.mkUninterpFun(symbol, args); }
-
-    void solveSystem(std::vector<ChClause> const & clauses, Engine & engine, VerificationResult expectedResult, bool validate) {
-        for (auto const & clause : clauses) { system.addClause(clause); }
-
-        auto normalizedSystem = Normalizer(logic).normalize(system);
-        auto hypergraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
-        auto res = engine.solve(*hypergraph);
-        auto answer = res.getAnswer();
-        ASSERT_EQ(answer, expectedResult);
-        if (validate) {
-            SystemVerificationResult systemResult(std::move(res), *hypergraph);
-            auto validationResult = Validator(logic).validate(*normalizedSystem.normalizedSystem, systemResult);
-            ASSERT_EQ(validationResult, Validator::Result::VALIDATED);
-        }
-    }
+class TPATest : public LIAEngineTest {
 };
 
 TEST_F(TPATest, test_TPA_simple_safe)
 {
-    Options options;
-    options.addOption(Options::LOGIC, "QF_LIA");
     options.addOption(Options::COMPUTE_WITNESS, "true");
     options.addOption(Options::ENGINE, TPAEngine::SPLIT_TPA);
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
     PTRef current = instantiatePredicate(s1, {x});
     PTRef next = instantiatePredicate(s1, {xp});
-    std::vector<ChClause> clauses{{
-            ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}},
+    std::vector<ChClause> clauses{
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}},
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_simple_unsafe)
 {
-    Options options;
     options.addOption(Options::LOGIC, "QF_LIA");
     options.addOption(Options::COMPUTE_WITNESS, "true");
     options.addOption(Options::ENGINE, TPAEngine::SPLIT_TPA);
@@ -93,17 +44,17 @@ TEST_F(TPATest, test_TPA_simple_unsafe)
     PTRef next = instantiatePredicate(s1, {xp});
     std::vector<ChClause> clauses{{
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}},
         {
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkGt(x, one)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGt(x, one)}, {UninterpretedPredicate{current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::UNSAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_CEX_zero) {
@@ -116,18 +67,18 @@ TEST_F(TPATest, test_TPA_CEX_zero) {
     PTRef next = instantiatePredicate(s1, {xp});
     std::vector<ChClause> clauses{{ // x' = 0 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         { // S1(x) and x' = x + 1 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         { // S1(x) and x = 0 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, zero)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, zero)}, {UninterpretedPredicate{current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::UNSAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_CEX_one) {
@@ -135,23 +86,23 @@ TEST_F(TPATest, test_TPA_CEX_one) {
     options.addOption(Options::LOGIC, "QF_LIA");
     options.addOption(Options::COMPUTE_WITNESS, "true");
     options.addOption(Options::ENGINE, TPAEngine::TPA);
-    SymRef s1 = mkPredicateSymbol("s1", {logic.getSort_int()});
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
     PTRef current = instantiatePredicate(s1, {x});
     PTRef next = instantiatePredicate(s1, {xp});
     std::vector<ChClause> clauses{{ // x' = 0 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         { // S1(x) and x' = x + 1 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         { // S1(x) and x = 1 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, one)}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, one)}, {UninterpretedPredicate{current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::UNSAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_CEX_six) {
@@ -164,18 +115,18 @@ TEST_F(TPATest, test_TPA_CEX_six) {
     PTRef next = instantiatePredicate(s1, {xp});
     std::vector<ChClause> clauses{{ // x' = 0 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         { // S1(x) and x' = x + 1 => S1(x')
             ChcHead{UninterpretedPredicate{next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
         },
         { // S1(x) and x = 6 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, logic.mkIntConst(6))}, {UninterpretedPredicate{current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, logic->mkIntConst(6))}, {UninterpretedPredicate{current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::UNSAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_chain_of_two_unsafe) {
@@ -191,27 +142,27 @@ TEST_F(TPATest, test_TPA_chain_of_two_unsafe) {
     PTRef predS2Next = instantiatePredicate(s2, {xp});
     std::vector<ChClause> clauses{{
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         {
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{predS1Current}}}
         },
         {
             ChcHead{UninterpretedPredicate{predS2Current}},
-            ChcBody{{logic.getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
         },
         {
             ChcHead{UninterpretedPredicate{predS2Next}},
-            ChcBody{{logic.mkEq(xp, logic.mkMinus(x, one))},
+            ChcBody{{logic->mkEq(xp, logic->mkMinus(x, one))},
                 {UninterpretedPredicate{predS2Current}}}
         },
         {
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkLt(x, zero)}, {UninterpretedPredicate{predS2Current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{predS2Current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::UNSAFE, true);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_chain_of_two_safe) {
@@ -227,27 +178,27 @@ TEST_F(TPATest, test_TPA_chain_of_two_safe) {
     PTRef predS2Next = instantiatePredicate(s2, {xp});
     std::vector<ChClause> clauses{{ // x = 0 => S1(x)
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkEq(xp, zero)}, {}}
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
         },
         { // S1(x) & x' = x + 1 => S1(x')
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{predS1Current}}}
         },
         { // S1(x) => S2(x)
             ChcHead{UninterpretedPredicate{predS2Current}},
-            ChcBody{{logic.getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
         },
         { // S2(x) & x' = x + 2 => S2(x')
             ChcHead{UninterpretedPredicate{predS2Next}},
-            ChcBody{{logic.mkEq(xp, logic.mkPlus(x, logic.mkIntConst(FastRational(2))))},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, logic->mkIntConst(FastRational(2))))},
                 {UninterpretedPredicate{predS2Current}}}
         },
         { // S2(x) & x < 0 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkLt(x, zero)}, {UninterpretedPredicate{predS2Current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{predS2Current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, false);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
 }
 
 TEST_F(TPATest, test_TPA_chain_regression) {
@@ -263,38 +214,38 @@ TEST_F(TPATest, test_TPA_chain_regression) {
     PTRef predS1Next = instantiatePredicate(s1, {xp, yp});
     PTRef predS2Current = instantiatePredicate(s2, {x, y});
     PTRef predS2Next = instantiatePredicate(s2, {xp, yp});
-    PTRef val = logic.mkIntConst(FastRational(5));
-    PTRef doubleVal = logic.mkIntConst(FastRational(10));
+    PTRef val = logic->mkIntConst(FastRational(5));
+    PTRef doubleVal = logic->mkIntConst(FastRational(10));
     std::vector<ChClause> clauses{{ // x = 0 and y = 5 => S1(x,y)
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkAnd(logic.mkEq(xp, zero), logic.mkEq(yp, val))}, {}}
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, zero), logic->mkEq(yp, val))}, {}}
         },
         { // S1(x,y) and x < 5 and x' = x + 1 and y' = y => S1(x',y')
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkAnd({logic.mkEq(xp, logic.mkPlus(x, one)),logic.mkEq(yp, y),logic.mkLt(x, val)})},
+            ChcBody{{logic->mkAnd({logic->mkEq(xp, logic->mkPlus(x, one)),logic->mkEq(yp, y),logic->mkLt(x, val)})},
                 {UninterpretedPredicate{predS1Current}}
             }
         },
         { // S1(x,y) and x >= 5 => S2(x,y)
             ChcHead{UninterpretedPredicate{predS2Current}},
-            ChcBody{{logic.mkGeq(x, val)}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->mkGeq(x, val)}, {UninterpretedPredicate{predS1Current}}}
         },
         { // S2(x,y) and x' = x + 1 and y' = y + 1 => S2(x',y')
             ChcHead{UninterpretedPredicate{predS2Next}},
-            ChcBody{{logic.mkAnd(
-                logic.mkEq(xp, logic.mkPlus(x, one)),
-                logic.mkEq(yp, logic.mkPlus(y, one))
+            ChcBody{{logic->mkAnd(
+                logic->mkEq(xp, logic->mkPlus(x, one)),
+                logic->mkEq(yp, logic->mkPlus(y, one))
             )
             },
                 {UninterpretedPredicate{predS2Current}}}
         },
         { // S2(x,y) and x = 10 and x != y => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkAnd(logic.mkEq(x, doubleVal), logic.mkNot(logic.mkEq(x, y)))},
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkAnd(logic->mkEq(x, doubleVal), logic->mkNot(logic->mkEq(x, y)))},
                 {UninterpretedPredicate{predS2Current}}}
         }};
-    TPAEngine engine(logic, options);
-    solveSystem(clauses, engine, VerificationResult::SAFE, false);
+    TPAEngine engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
 }
 
 TEST_F(TPATest, test_transformContractVertex) {
@@ -310,29 +261,29 @@ TEST_F(TPATest, test_transformContractVertex) {
     PTRef predS2Next = instantiatePredicate(s2, {xp});
     std::vector<ChClause> clauses{{ // x < 0 => S1(x)
         ChcHead{UninterpretedPredicate{predS1Next}},
-        ChcBody{{logic.mkLt(xp, zero)}, {}}
+        ChcBody{{logic->mkLt(xp, zero)}, {}}
     },
         { // x > 0 => S1(x)
             ChcHead{UninterpretedPredicate{predS1Next}},
-            ChcBody{{logic.mkGt(xp, zero)}, {}}
+            ChcBody{{logic->mkGt(xp, zero)}, {}}
         },
         { // S1(x) => S2(x)
             ChcHead{UninterpretedPredicate{predS2Current}},
-            ChcBody{{logic.getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
+            ChcBody{{logic->getTerm_true()}, {UninterpretedPredicate{predS1Current}}}
         },
         { // S2(x) and (x < 0 => x' = x - 1) and (x > 0 => x' = x + 1 => S2(x')
             ChcHead{UninterpretedPredicate{predS2Next}},
-            ChcBody{{logic.mkAnd(
-                logic.mkImpl(logic.mkLt(x, zero), logic.mkEq(xp, logic.mkMinus(x, one))),
-                logic.mkImpl(logic.mkGt(x, zero), logic.mkEq(xp, logic.mkPlus(x, one)))
+            ChcBody{{logic->mkAnd(
+                logic->mkImpl(logic->mkLt(x, zero), logic->mkEq(xp, logic->mkMinus(x, one))),
+                logic->mkImpl(logic->mkGt(x, zero), logic->mkEq(xp, logic->mkPlus(x, one)))
                 )},
                 {UninterpretedPredicate{predS2Current}}}
         },
         { // S2(x) & x = 0 => false
-            ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-            ChcBody{{logic.mkEq(x, zero)}, {UninterpretedPredicate{predS2Current}}}
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkEq(x, zero)}, {UninterpretedPredicate{predS2Current}}}
         }};
-    TPAEngine engine(logic, options);
+    TPAEngine engine(*logic, options);
     // FIXME: Enable validation when TPA can compute witnesses for chains
-    solveSystem(clauses, engine, VerificationResult::SAFE, true);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }


### PR DESCRIPTION
As a preparation for producing witnesses for nonlinear systems (from Spacer engine), we change the format of the invalidity witness. The new style is similar to what Eldarica prints out. The proof is a sequence of steps where each step is a derived fact (instantiation of an uninterpreted predicate with constants as the arguments). Moreover, we remember the indices for the premises of each derivation step and the edge that was used for this derivation step.

The validator has been updated to validate this new format. It also meant that we removed the distinction between Graph- and System- invalidity witness.

Unfortunately, we now require the corresponding ChcDirectedHyperGraph to validate InvalidityWitness, which means that we have to keep around a copy of the original graph, if we are making any transformation passes.

Maybe we will have to re-introduce a format for proof for normalized system in the future again. But I need to understand precisely the representation of the normalized system and how can we keep references to clauses in the system in the InvalidityWitness.