### PR TITLE
Spacer: Implement logging of the unsatisfiability proof

### DIFF
--- a/src/Validator.cc
+++ b/src/Validator.cc
@@ -122,6 +122,11 @@ Validator::validateInvalidityWitness(ChcDirectedHyperGraph const & graph, Invali
     ChcDirectedHyperGraph::VertexInstances vertexInstances(graph);
     if (derivation[0].derivedFact != logic.getTerm_true()) {
         assert(false);
+        std::cerr << "; Validator: Invalidity witness does not start with TRUE!\n";
+        return Result::NOT_VALIDATED;
+    }
+    if (derivation.last().derivedFact != logic.getTerm_false()) {
+        std::cerr << "; Validator: Root of the invalidity witness is not FALSE!\n";
         return Result::NOT_VALIDATED;
     }
     for (std::size_t i = 1; i < derivationSize; ++i) {

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -58,8 +58,18 @@ public:
         DerivationStep &        last()       { assert(size() > 0); return derivationSteps[size() - 1]; }
         DerivationStep const &  last() const { assert(size() > 0); return derivationSteps[size() - 1]; }
         std::size_t size() const { return derivationSteps.size(); }
-private:
+    private:
         std::vector<DerivationStep> derivationSteps;
+
+    public:
+        Derivation() = default;
+        Derivation(std::vector<DerivationStep> derivationSteps) : derivationSteps(std::move(derivationSteps)) {}
+
+        using const_iterator = decltype(derivationSteps)::const_iterator;
+
+        const_iterator begin() const { return derivationSteps.begin(); }
+        const_iterator end() const { return derivationSteps.end(); }
+
     };
 
 private:

--- a/src/engine/Spacer.cc
+++ b/src/engine/Spacer.cc
@@ -727,8 +727,11 @@ void computePremiseInstances(DerivationDatabase::Entry const & databaseEntry, En
     }
     auto model = solver.getModel();
     std::transform(sourcePredicates.begin(), sourcePredicates.end(), std::back_inserter(entry.premiseInstances), [&](PTRef premise){
-        PTRef premiseInstance = model->evaluate(premise);
-//        std::cout << logic.pp(premiseInstance) << std::endl;
+        auto vars = TermUtils(logic).predicateArgsInOrder(premise);
+        vec<PTRef> evaluatedVars(vars.size());
+        std::transform(vars.begin(), vars.end(), evaluatedVars.begin(), [&](PTRef var){ return model->evaluate(var); });
+        PTRef premiseInstance = logic.insertTerm(logic.getSymRef(premise), std::move(evaluatedVars));
+//        std::cout << logic.pp(premise) << " -> " << logic.pp(premiseInstance) << std::endl;
         return premiseInstance;
     });
 }

--- a/src/engine/Spacer.h
+++ b/src/engine/Spacer.h
@@ -11,11 +11,10 @@
 
 class Spacer : public Engine {
     Logic & logic;
+    Options const & options;
 
 public:
-    Spacer(Logic & logic, Options const &): logic(logic) {}
-
-    explicit Spacer(Logic & logic) : logic(logic) {}
+    Spacer(Logic & logic, Options const & options) : logic(logic), options(options) {}
 
     [[nodiscard]] VerificationResult solve(ChcDirectedHyperGraph & system) override;
 };

--- a/src/transformers/SimpleChainSummarizer.cc
+++ b/src/transformers/SimpleChainSummarizer.cc
@@ -53,10 +53,165 @@ Transformer::TransformationResult SimpleChainSummarizer::transform(std::unique_p
     return {std::move(graph), std::move(translator)};
 }
 
+namespace{
+class EdgeConverter {
+    Logic & logic;
+    TermUtils utils;
+    TimeMachine timeMachine;
+    VersionManager manager;
+    NonlinearCanonicalPredicateRepresentation const & predicateRepresentation;
+public:
+    EdgeConverter(Logic & logic, NonlinearCanonicalPredicateRepresentation const & predicateRepresentation) :
+    logic(logic), utils(logic), timeMachine(logic), manager(logic), predicateRepresentation(predicateRepresentation) {}
+
+    DirectedEdge operator()(DirectedHyperEdge const & edge) {
+        assert(edge.from.size() == 1);
+        auto source = edge.from[0];
+        auto target = edge.to;
+        TermUtils::substitutions_map subst;
+        {
+            auto sourceVars = utils.predicateArgsInOrder(predicateRepresentation.getSourceTermFor(source));
+            for (PTRef sourceVar : sourceVars) {
+                PTRef newVar = timeMachine.getVarVersionZero(manager.toBase(sourceVar));
+                subst.insert({sourceVar, newVar});
+            }
+        }
+        {
+            auto targetVars = utils.predicateArgsInOrder(predicateRepresentation.getTargetTermFor(target));
+            for (PTRef targetVar : targetVars) {
+                PTRef newVar = timeMachine.sendVarThroughTime(timeMachine.getVarVersionZero(manager.toBase(targetVar)), 1);
+                subst.insert({targetVar, newVar});
+            }
+        }
+
+        PTRef newLabel = TermUtils(logic).varSubstitute(edge.fla.fla, subst);
+        return DirectedEdge{.from = edge.from[0], .to = edge.to, .fla = {newLabel}, .id = {edge.id}};
+    }
+};
+
+class VersionedPredicate {
+    Logic & logic;
+    TermUtils utils;
+    TimeMachine timeMachine;
+    VersionManager manager;
+    NonlinearCanonicalPredicateRepresentation const & predicateRepresentation;
+public:
+    VersionedPredicate(Logic & logic, NonlinearCanonicalPredicateRepresentation const & predicateRepresentation) :
+        logic(logic), utils(logic), timeMachine(logic), manager(logic), predicateRepresentation(predicateRepresentation) {}
+
+    PTRef operator()(SymRef predicateSymbol) {
+        vec<PTRef> baseVars;
+            auto sourceVars = utils.predicateArgsInOrder(predicateRepresentation.getSourceTermFor(predicateSymbol));
+            for (PTRef sourceVar : sourceVars) {
+                PTRef newVar = timeMachine.getVarVersionZero(manager.toBase(sourceVar));
+                baseVars.push(newVar);
+            }
+        return logic.insertTerm(predicateSymbol, std::move(baseVars));
+    }
+};
+}
+
 InvalidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(InvalidityWitness witness) {
     if (summarizedChains.empty()) { return witness; }
-    // TODO: Implement this
-    return InvalidityWitness();
+    using DerivationStep = InvalidityWitness::Derivation::DerivationStep;
+
+    for (auto const & chain : summarizedChains) {
+        auto const & replacingEdge = chain.second;
+        EId eid = replacingEdge.id;
+        // replace all occurrences of this edge
+        while(true) {
+            auto const & derivation = witness.getDerivation();
+            auto it = std::find_if(derivation.begin(), derivation.end(), [eid](auto const & step){ return step.clauseId == eid; });
+            if (it == derivation.end()) { break; }
+            // Replace this step with the sequence of steps corresponding to the summarized chain
+            std::vector<DerivationStep> newSteps;
+            // 1. Copy all the steps before the one to be replaced
+            std::copy(derivation.begin(), it, std::back_inserter(newSteps));
+            std::size_t firstShiftedIndex = newSteps.size();
+            // 2. Replace the summarized step
+            DerivationStep const & summarizedStep = *it;
+            // 2a. Compute instances for the summarized nodes
+            // 2aa. Compute path constraint
+            vec<PTRef> edgeConstraints;
+            std::vector<DirectedEdge> simpleChain;
+            EdgeConverter converter(logic, predicateRepresentation);
+            std::transform(chain.first.begin(), chain.first.end(), std::back_inserter(simpleChain), converter);
+            for (std::size_t i = 0; i < simpleChain.size(); ++i) {
+                PTRef baseConstraint = simpleChain[i].fla.fla;
+                edgeConstraints.push(TimeMachine(logic).sendFlaThroughTime(baseConstraint,i));
+            }
+            // 2ab Compute constraints for the end points
+            TermUtils::substitutions_map subst;
+            TermUtils utils(logic);
+            assert(replacingEdge.from.size() == 1);
+            assert(summarizedStep.premises.size() == 1);
+            assert(logic.getSymRef(summarizedStep.derivedFact) == replacingEdge.to);
+            assert(logic.getSymRef(derivation[summarizedStep.premises.front()].derivedFact) == replacingEdge.from[0]);
+            VersionedPredicate versionPredicate(logic, predicateRepresentation);
+            PTRef sourcePredicate = versionPredicate(replacingEdge.from[0]);
+            PTRef targetPredicate = TimeMachine(logic).sendFlaThroughTime(versionPredicate(replacingEdge.to), simpleChain.size());
+            utils.mapFromPredicate(targetPredicate, summarizedStep.derivedFact, subst);
+            utils.mapFromPredicate(sourcePredicate, derivation[summarizedStep.premises.front()].derivedFact, subst);
+            SMTConfig config;
+            MainSolver solver(logic, config, "");
+            solver.insertFormula(logic.mkAnd(std::move(edgeConstraints)));
+            for (auto const & [var,value] : subst) {
+                assert(logic.isVar(var) and logic.isConstant(value));
+                solver.insertFormula(logic.mkEq(var, value));
+            }
+            // 2ac Compute values for summarized predicates from model
+            auto res = solver.check();
+            if (res != s_True) { throw std::logic_error("Summarized chain should have been satisfiable!"); }
+            auto model = solver.getModel();
+            std::vector<PTRef> intermediatePredicateInstances;
+            for (std::size_t i = 1; i < simpleChain.size(); ++i) {
+                SymRef sourceSymbol = simpleChain[i].from;
+                PTRef predicate = TimeMachine(logic).sendFlaThroughTime(versionPredicate(sourceSymbol), i);
+                auto vars = utils.predicateArgsInOrder(predicate);
+                subst.clear();
+                for (PTRef var : vars) {
+                    subst.insert({var, model->evaluate(var)});
+                }
+                intermediatePredicateInstances.push_back(utils.varSubstitute(predicate, subst));
+            }
+            // 2b. Create new steps based on intermediate predicate instances
+            assert(not newSteps.empty());
+            assert(summarizedStep.premises.size() == 1);
+            for (std::size_t i = 0; i < intermediatePredicateInstances.size(); ++i) {
+                DerivationStep step;
+                step.derivedFact = intermediatePredicateInstances[i];
+                step.index = newSteps.size();
+                // MB: First of the new steps has the same premise as the summarized step
+                step.premises = {i == 0 ? summarizedStep.premises.front() : newSteps.size() - 1};
+                step.clauseId = simpleChain[i].id;
+                newSteps.push_back(std::move(step));
+            }
+            std::size_t diff = intermediatePredicateInstances.size();
+            // 2c. fix the step deriving the target of the summarized chain
+            DerivationStep step = summarizedStep;
+            assert(step.premises.size() == 1);
+            assert(not newSteps.empty());
+            step.premises[0] = newSteps.size() - 1;
+            step.index += diff;
+            step.clauseId = simpleChain.back().id;
+            newSteps.push_back(std::move(step));
+            // 3. copy all steps after the one replaced and update their premise indices
+            std::transform(it+1, derivation.end(), std::back_inserter(newSteps), [diff, firstShiftedIndex](auto const & step){
+                auto newStep = step;
+                for (auto & premiseIndex : newStep.premises) {
+                    if (premiseIndex >= firstShiftedIndex) {
+                        premiseIndex += diff;
+                    }
+                }
+                newStep.index += diff;
+                return newStep;
+            });
+            // 4. Replace the derivation
+            InvalidityWitness::Derivation newDerivation(std::move(newSteps));
+            witness.setDerivation(std::move(newDerivation));
+        }
+    }
+    return witness;
 }
 
 ValidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(ValidityWitness witness) {

--- a/test/test_Spacer.cc
+++ b/test/test_Spacer.cc
@@ -204,3 +204,21 @@ TEST_F(Spacer_LRA_Test, test_UnsatProofNondeterministicSystem)
     solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
+TEST_F(Spacer_LRA_Test, test_UnsatProof_FactWithNoConstraints)
+{
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef P = mkPredicateSymbol("P", {});
+    std::vector<ChClause> clauses{
+        { // true => P()
+            ChcHead{UninterpretedPredicate{instantiatePredicate(P, {})}},
+            ChcBody{InterpretedFla{logic->getTerm_true()}, {}}
+        },
+        { // P() => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{InterpretedFla{logic->getTerm_true()}, {UninterpretedPredicate{instantiatePredicate(P,{})}}}
+        },
+    };
+    Spacer engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
+}
+


### PR DESCRIPTION
Previously, we did not have a way to produce a proof of unsatisfiability from the Spacer engine.
I thought of two possibilities: either log the proof obligations, building the proof from bottom to leaves, or log the must summaries, building the proof from leaves to bottom.
I decided to go for the latter, since it seems like less bookkeeping. For each must summary, we now also remember what were its premises, i.e., from which constrained predicates and using which edge we can derive the current must summary (constrained fact in current node). This is almost the same as our proof format, but not quite. Single must summary can cover a large set of states, in the proof format we want to pick single state.
We solve this by post-processing the database of must summaries to pick for each one a single state.