### PR TITLE
Spacer: Do not repeat work when checking edges with single source

### DIFF
--- a/src/engine/Spacer.cc
+++ b/src/engine/Spacer.cc
@@ -415,12 +415,16 @@ SpacerContext::BoundedSafetyResult SpacerContext::boundSafety(std::size_t curren
 }
 
 SpacerContext::QueryResult SpacerContext::implies(PTRef antecedent, PTRef consequent) {
+    QueryResult qres;
+    if (antecedent == logic.getTerm_false()) {
+        qres.answer = QueryAnswer::VALID;
+        return qres;
+    }
     SMTConfig config;
     MainSolver solver(logic, config, "checker");
     solver.insertFormula(antecedent);
     solver.insertFormula(logic.mkNot(consequent));
     auto res = solver.check();
-    QueryResult qres;
     if (res == s_True) {
         qres.answer = QueryAnswer::INVALID;
         qres.model = solver.getModel();

--- a/src/engine/Spacer.cc
+++ b/src/engine/Spacer.cc
@@ -208,7 +208,7 @@ class SpacerContext {
         QueryAnswer answer;
         std::unique_ptr<Model> model;
     };
-    QueryResult implies(PTRef antecedent, PTRef consequent);
+    QueryResult implies(PTRef antecedent, PTRef consequent) const;
 
     struct ItpQueryResult {
         QueryAnswer answer;
@@ -414,7 +414,7 @@ SpacerContext::BoundedSafetyResult SpacerContext::boundSafety(std::size_t curren
     return BoundedSafetyResult::SAFE; // not reachable at this bound
 }
 
-SpacerContext::QueryResult SpacerContext::implies(PTRef antecedent, PTRef consequent) {
+SpacerContext::QueryResult SpacerContext::implies(PTRef antecedent, PTRef consequent) const {
     QueryResult qres;
     if (antecedent == logic.getTerm_false()) {
         qres.answer = QueryAnswer::VALID;


### PR DESCRIPTION
When checking reachability of a proof obligation, we first check
reachability with must summaries and then unreachability with may
summaries. If both checks fails, then we systematically iterate over
vertices to find the first one which makes reachability feasible when
may summary is used instead of the must summary.
For edges with single source this unnecessarily duplicates work, because
when we fail to prove unreachability with may summaries, we already have
the model to generate proof obligation at that point, so we do not need
to repeat the same check later.