### PR TITLE
Generalize NonLoopEliminator and add new simplification pass

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,7 @@ target_sources(golem_lib
     PRIVATE graph/GraphTransformations.cc
     PRIVATE transformers/CommonUtils.cc
     PRIVATE transformers/SimpleChainSummarizer.cc
-    PRIVATE transformers/NonLoopEliminator.cc
+    PRIVATE transformers/NodeEliminator.cc
     PRIVATE transformers/MultiEdgeMerger.cc
     PRIVATE transformers/FalseClauseRemoval.cc
     PRIVATE transformers/RemoveUnreachableNodes.cc

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -323,7 +323,7 @@ void ChcInterpreterContext::interpretCheckSat() {
     }
 
     TransformationPipeline::pipeline_t transformations;
-    transformations.push_back(std::make_unique<SimpleChainSummarizer>(logic));
+    transformations.push_back(std::make_unique<SimpleChainSummarizer>());
     transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
     transformations.push_back(std::make_unique<SimpleNodeEliminator>());
     auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2020-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -18,6 +18,7 @@
 #include "Normalizer.h"
 #include "transformers/RemoveUnreachableNodes.h"
 #include "transformers/SimpleChainSummarizer.h"
+#include "transformers/NodeEliminator.h"
 #include "transformers/TransformationPipeline.h"
 
 using namespace osmttokens;
@@ -324,6 +325,7 @@ void ChcInterpreterContext::interpretCheckSat() {
     TransformationPipeline::pipeline_t transformations;
     transformations.push_back(std::make_unique<SimpleChainSummarizer>(logic));
     transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
+    transformations.push_back(std::make_unique<SimpleNodeEliminator>());
     auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));
     hypergraph = std::move(newGraph);
 

--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -456,3 +456,32 @@ ChcDirectedHyperGraph::VertexInstances::VertexInstances(ChcDirectedHyperGraph co
         }
     });
 }
+
+bool hasHyperEdge(
+    SymRef vertex,
+    AdjacencyListsGraphRepresentation const & adjacencyRepresentation,
+    ChcDirectedHyperGraph const & graph
+) {
+    auto const & incoming = adjacencyRepresentation.getIncomingEdgesFor(vertex);
+    auto const & outgoing = adjacencyRepresentation.getOutgoingEdgesFor(vertex);
+    return std::any_of(incoming.begin(), incoming.end(), [&](EId eid){ return graph.getSources(eid).size() > 1; }) or
+           std::any_of(outgoing.begin(), outgoing.end(), [&](EId eid){ return graph.getSources(eid).size() > 1; });
+}
+
+bool isNonLoopNode(
+    SymRef vertex,
+    AdjacencyListsGraphRepresentation const & adjacencyRepresentation,
+    ChcDirectedHyperGraph const & graph
+) {
+    auto const & outgoing = adjacencyRepresentation.getOutgoingEdgesFor(vertex);
+    return std::none_of(outgoing.begin(), outgoing.end(), [&](EId eid){ return graph.getTarget(eid) == vertex; });
+}
+
+bool isSimpleNode(
+    SymRef vertex,
+    AdjacencyListsGraphRepresentation const & adjacencyRepresentation
+) {
+    auto const & outgoing = adjacencyRepresentation.getOutgoingEdgesFor(vertex);
+    auto const & incoming = adjacencyRepresentation.getIncomingEdgesFor(vertex);
+    return incoming.size() == 1 or outgoing.size() == 1;
+}

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -342,4 +342,10 @@ public:
     }
 };
 
+bool isNonLoopNode(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph);
+
+bool hasHyperEdge(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph);
+
+bool isSimpleNode(SymRef, AdjacencyListsGraphRepresentation const &);
+
 #endif //GOLEM_CHCGRAPH_H

--- a/src/transformers/BasicTransformationPipelines.h
+++ b/src/transformers/BasicTransformationPipelines.h
@@ -9,7 +9,7 @@
 
 #include "FalseClauseRemoval.h"
 #include "MultiEdgeMerger.h"
-#include "NonLoopEliminator.h"
+#include "NodeEliminator.h"
 #include "TransformationPipeline.h"
 
 namespace Transformations {

--- a/src/transformers/NodeEliminator.h
+++ b/src/transformers/NodeEliminator.h
@@ -42,14 +42,22 @@ public:
     predicate_t shouldEliminateNode;
 };
 
-struct IsNonLoopNode {
+struct NonLoopEliminatorPredicate {
     bool operator()(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph) const;
 };
 
 class NonLoopEliminator : public NodeEliminator {
 public:
-    NonLoopEliminator() : NodeEliminator(IsNonLoopNode()) {}
+    NonLoopEliminator() : NodeEliminator(NonLoopEliminatorPredicate{}) {}
 };
 
+struct SimpleNodeEliminatorPredicate {
+    bool operator()(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph) const;
+};
+
+class SimpleNodeEliminator : public NodeEliminator {
+public:
+    SimpleNodeEliminator() : NodeEliminator(SimpleNodeEliminatorPredicate()) {}
+};
 
 #endif //GOLEM_NODEELIMINATOR_H

--- a/src/transformers/NodeEliminator.h
+++ b/src/transformers/NodeEliminator.h
@@ -1,19 +1,24 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
 
-#ifndef GOLEM_NONLOOPELIMINATOR_H
-#define GOLEM_NONLOOPELIMINATOR_H
+#ifndef GOLEM_NODEELIMINATOR_H
+#define GOLEM_NODEELIMINATOR_H
 
 #include "Transformer.h"
+
+
 
 /*
  * Tries to eliminate all nodes that do not have a self-loop edge
  */
-class NonLoopEliminator : public Transformer {
+class NodeEliminator : public Transformer {
+    using predicate_t = std::function<bool(SymRef,AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const &)>;
 public:
+    NodeEliminator(predicate_t shouldEliminateNode) : shouldEliminateNode(std::move(shouldEliminateNode)) {}
+
     TransformationResult transform(std::unique_ptr<ChcDirectedHyperGraph> graph) override;
 
     class BackTranslator : public WitnessBackTranslator {
@@ -33,7 +38,18 @@ public:
         Logic & logic;
         NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     };
+
+    predicate_t shouldEliminateNode;
+};
+
+struct IsNonLoopNode {
+    bool operator()(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph) const;
+};
+
+class NonLoopEliminator : public NodeEliminator {
+public:
+    NonLoopEliminator() : NodeEliminator(IsNonLoopNode()) {}
 };
 
 
-#endif //GOLEM_NONLOOPELIMINATOR_H
+#endif //GOLEM_NODEELIMINATOR_H

--- a/src/transformers/NodeEliminator.h
+++ b/src/transformers/NodeEliminator.h
@@ -9,10 +9,10 @@
 
 #include "Transformer.h"
 
-
-
 /*
- * Tries to eliminate all nodes that do not have a self-loop edge
+ * Transformation pass that eliminates some nodes from the graph, using contraction.
+ *
+ * The predicate determining the nodes to eliminate is passed to the constructor.
  */
 class NodeEliminator : public Transformer {
     using predicate_t = std::function<bool(SymRef,AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const &)>;

--- a/src/transformers/NonLoopEliminator.h
+++ b/src/transformers/NonLoopEliminator.h
@@ -33,10 +33,6 @@ public:
         Logic & logic;
         NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     };
-
-private:
-    std::vector<SymRef> nonloopingVertices(ChcDirectedHyperGraph const & graph, AdjacencyListsGraphRepresentation const &);
-
 };
 
 

--- a/src/transformers/SimpleChainSummarizer.cc
+++ b/src/transformers/SimpleChainSummarizer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -9,7 +9,7 @@
 #include "CommonUtils.h"
 
 Transformer::TransformationResult SimpleChainSummarizer::transform(std::unique_ptr<ChcDirectedHyperGraph> graph) {
-    auto translator = std::make_unique<SimpleChainBackTranslator>(logic, graph->predicateRepresentation());
+    auto translator = std::make_unique<BackTranslator>(graph->getLogic(), graph->predicateRepresentation());
     while(true) {
         AdjacencyListsGraphRepresentation adjacencyList = AdjacencyListsGraphRepresentation::from(*graph);
         auto isTrivial = [&](SymRef sym) {
@@ -55,7 +55,7 @@ Transformer::TransformationResult SimpleChainSummarizer::transform(std::unique_p
     return {std::move(graph), std::move(translator)};
 }
 
-InvalidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(InvalidityWitness witness) {
+InvalidityWitness SimpleChainSummarizer::BackTranslator::translate(InvalidityWitness witness) {
     if (summarizedChains.empty()) { return witness; }
 
     for (auto const & [chain, replacingEdge] : summarizedChains) {
@@ -73,7 +73,7 @@ InvalidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(In
     return witness;
 }
 
-ValidityWitness SimpleChainSummarizer::SimpleChainBackTranslator::translate(ValidityWitness witness) {
+ValidityWitness SimpleChainSummarizer::BackTranslator::translate(ValidityWitness witness) {
     if (summarizedChains.empty()) { return witness; }
     auto definitions = witness.getDefinitions();
     // TODO: assert that we have true and false already

--- a/src/transformers/SimpleChainSummarizer.h
+++ b/src/transformers/SimpleChainSummarizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -13,11 +13,11 @@ class SimpleChainSummarizer : public Transformer {
 public:
     TransformationResult transform(std::unique_ptr<ChcDirectedHyperGraph> graph) override;
 
-    SimpleChainSummarizer(Logic & logic) : logic(logic) {}
+    SimpleChainSummarizer() = default;
 
-    class SimpleChainBackTranslator : public WitnessBackTranslator {
+    class BackTranslator : public WitnessBackTranslator {
     public:
-        SimpleChainBackTranslator(Logic & logic, NonlinearCanonicalPredicateRepresentation predicateRepresentation)
+        BackTranslator(Logic & logic, NonlinearCanonicalPredicateRepresentation predicateRepresentation)
         : logic(logic), predicateRepresentation(std::move(predicateRepresentation)) {}
 
         InvalidityWitness translate(InvalidityWitness witness) override;
@@ -33,9 +33,6 @@ public:
         Logic & logic;
         NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     };
-private:
-    Logic & logic;
-
 };
 
 

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 #include "graph/ChcGraphBuilder.h"
 #include "transformers/SimpleChainSummarizer.h"
-#include "transformers/NonLoopEliminator.h"
+#include "transformers/NodeEliminator.h"
 #include "Validator.h"
 #include "engine/Spacer.h"
 

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -67,7 +67,7 @@ TEST_F(Transformer_test, test_SingleChain_NoLoop) {
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     ValidityWitness witness{};
     auto translatedWitness = translator->translate(witness);
     Validator validator(logic);
@@ -101,7 +101,7 @@ TEST_F(Transformer_test, test_TwoChains_WithLoop) {
     );
     auto hypergraph = systemToGraph(system);
     auto originalGraph = *hypergraph;
-    auto [newGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hypergraph));
+    auto [newGraph, translator] = SimpleChainSummarizer().transform(std::move(hypergraph));
     VersionManager manager{logic};
     PTRef predicate = manager.sourceFormulaToBase(newGraph->getStateVersion(s2));
     PTRef var = logic.getPterm(predicate)[0];
@@ -139,7 +139,7 @@ TEST_F(Transformer_test, test_OutputFromEngine) {
     );
     auto hypergraph = systemToGraph(system);
     auto originalGraph = *hypergraph;
-    auto [newGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hypergraph));
+    auto [newGraph, translator] = SimpleChainSummarizer().transform(std::move(hypergraph));
     hypergraph = std::move(newGraph);
     auto res = Spacer(logic, options).solve(*hypergraph);
     ASSERT_EQ(res.getAnswer(), VerificationAnswer::SAFE);
@@ -161,7 +161,7 @@ TEST_F(Transformer_test, test_ChainSummarizer_TwoStepChain_Unsafe) {
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     Options options;
     options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = Spacer(logic, options).solve(*summarizedGraph);
@@ -190,7 +190,7 @@ TEST_F(Transformer_test, test_ChainSummarizer_ThreeStepChain_Unsafe) {
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     Options options;
     options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = Spacer(logic, options).solve(*summarizedGraph);
@@ -229,7 +229,7 @@ TEST_F(Transformer_test, test_ChainSummarizer_TwoChains_Unsafe) {
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     Options options;
     options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = Spacer(logic, options).solve(*summarizedGraph);
@@ -259,7 +259,7 @@ TEST_F(Transformer_test, test_ChainSummarizer_SameChainTwice_SafeFact_Unsafe) {
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     Options options;
     options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = Spacer(logic, options).solve(*summarizedGraph);
@@ -289,7 +289,7 @@ TEST_F(Transformer_test, test_ChainSummarizer_SameChainTwice_DifferentFact_Unsaf
     );
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
-    auto [summarizedGraph, translator] = SimpleChainSummarizer(logic).transform(std::move(hyperGraph));
+    auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
     Options options;
     options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = Spacer(logic, options).solve(*summarizedGraph);


### PR DESCRIPTION
This generalizes NonLoopEliminator to a pass that eliminates, by contraction, all nodes accepted by a specified predicate.
With this, we re-use all the functionality to create a simplification pass that eliminates all non-looping nodes, without hyperedges, and with at most one incoming or outgoing edge.

Contracting such nodes does not increase the number of edges (in fact it decreases the number by one).
The simplification seems beneficial on CHC-COMP benchmarks.