### PR TITLE
TPA: Fix bug in the analysis of transition-system chain

### DIFF
--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -1412,7 +1412,7 @@ VerificationResult TransitionSystemNetworkManager::solve() && {
             EId nextEdge = getOutgoingEdge(current);
 //            std::cout << "Reached states in node " << current.id << ": " << logic.pp(explanation) << std::endl;
             getNode(current).trulyReached = explanation;
-            PTRef nextConditions = getInitialStates(graph.getTarget(nextEdge));
+            PTRef nextConditions = logic.mkNot(getNode(graph.getTarget(nextEdge)).trulySafe);
             auto [edgeRes, edgeExplanation] = queryEdge(nextEdge, explanation, nextConditions);
             if (reachable(edgeRes)) { // Edge propagates forward
                 auto next = graph.getTarget(nextEdge);


### PR DESCRIPTION
When backtracking from a target TS to a source TS, after the (previously) truly reached in the source has been blocked, we compute a new set of truly reached states in the source. Then we want to check the edge again to the target.
However, at this point, we were trying the INITIAL states of the target's TS. This is not correct, because we have not updated the initial states of the TS before, we have only updated the truly safe states, which is exactly what should be considered at this point. We want to know if from the truly reached of source TS we can reach something that is NOT truly safe in the target TS.