### PR TITLE
TPA: Handle properly special cases of trivial transition systems

### DIFF
--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -392,6 +392,11 @@ VerificationAnswer TPABase::solveTransitionSystem(TransitionSystem & system) {
 }
 
 VerificationAnswer TPABase::solve() {
+    auto res = checkTrivialUnreachability();
+    assert(res != VerificationAnswer::UNSAFE);
+    if (res == VerificationAnswer::SAFE) {
+        return res;
+    }
     unsigned short power = 0;
     while (true) {
         auto res = checkPower(power);
@@ -405,6 +410,25 @@ VerificationAnswer TPABase::solve() {
     }
 }
 
+VerificationAnswer TPABase::checkTrivialUnreachability() {
+    if (query == logic.getTerm_false()) {
+        // TODO: Check UNSAT with solver?
+        explanation.power = 0;
+        explanation.relationType = TPAType::LESS_THAN;
+        explanation.invariantType = SafetyExplanation::TransitionInvariantType::RESTRICTED_TO_QUERY;
+        explanation.fixedPointType = SafetyExplanation::FixedPointType::LEFT;
+        return VerificationAnswer::SAFE;
+    }
+    if (init == logic.getTerm_false()) {
+        // TODO: Check UNSAT with solver?
+        explanation.power = 0;
+        explanation.relationType = TPAType::LESS_THAN;
+        explanation.invariantType = SafetyExplanation::TransitionInvariantType::RESTRICTED_TO_INIT;
+        explanation.fixedPointType = SafetyExplanation::FixedPointType::RIGHT;
+        return VerificationAnswer::SAFE;
+    }
+    return VerificationAnswer::UNKNOWN;
+}
 
 VerificationAnswer TPASplit::checkPower(unsigned short power) {
     TRACE(1, "Checking power " << power)

--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -197,6 +197,8 @@ protected:
     PTRef computeIdentity() const;
 
     void resetExplanation();
+
+    VerificationAnswer checkTrivialUnreachability();
 };
 
 class TPASplit : public TPABase {


### PR DESCRIPTION
If TPA was queried with a transition system that has empty bad states, it ran into an assertion that the interpolant is not logical true. This assertion is, in general, useful to detect incorrect behaviour of the algorithm, so we would like to keep it, even though in this special case of `query == false` such interpolant is correct. Instead, we check for these special cases beforehand.

For now we only make syntactic check. It is possible we should do proper SMT check on the initial and query states.