### PR TITLE
CI: Update MacOS image in CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,8 @@ jobs:
 
     build-macos:
         macos:
-            xcode: 13.4.1
+            xcode: 14.2.0
+        resource_class: macos.x86.medium.gen2
         steps:
             - run: echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $BASH_ENV
             - run:


### PR DESCRIPTION
This follows the suggestion at https://circleci.com/docs/using-macos/,
following the deprecation announcement: https://discuss.circleci.com/t/macos-resource-deprecation-update/46891