### PR TITLE
Engines: Refactor computation of witnesses for transition systems

### DIFF
--- a/src/Witnesses.cc
+++ b/src/Witnesses.cc
@@ -178,3 +178,17 @@ ValidityWitness::fromTransitionSystem(Logic & logic, ChcDirectedGraph const & gr
     ValidityWitness::definitions_t definitions{{unversionedPredicate, graphInvariant}};
     return ValidityWitness(std::move(definitions));
 }
+
+VerificationResult
+translateTransitionSystemResult(TransitionSystemVerificationResult result, ChcDirectedGraph const & graph, TransitionSystem const & transitionSystem) {
+    switch (result.answer) {
+        case VerificationAnswer::SAFE:
+            return {VerificationAnswer::SAFE, ValidityWitness::fromTransitionSystem(graph.getLogic(), graph, transitionSystem, std::get<PTRef>(result.witness))};
+        case VerificationAnswer::UNSAFE:
+            return {VerificationAnswer::UNSAFE, InvalidityWitness::fromTransitionSystem(graph, std::get<std::size_t>(result.witness))};
+        case VerificationAnswer::UNKNOWN:
+            return VerificationResult(VerificationAnswer::UNKNOWN);
+    }
+    assert(false);
+    return VerificationResult(VerificationAnswer::UNKNOWN);
+}

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -130,4 +130,11 @@ public:
     void printWitness(std::ostream & out, Logic & logic) const;
 };
 
+struct TransitionSystemVerificationResult {
+    VerificationAnswer answer;
+    std::variant<std::size_t, PTRef> witness; // Unrolling number or state inductive invariant
+};
+
+VerificationResult translateTransitionSystemResult(TransitionSystemVerificationResult result, ChcDirectedGraph const & graph, TransitionSystem const & ts);
+
 #endif // GOLEM_WITNESSES_H

--- a/src/engine/Bmc.h
+++ b/src/engine/Bmc.h
@@ -30,10 +30,11 @@ public:
         return VerificationResult(VerificationAnswer::UNKNOWN);
     }
 
-    VerificationResult solve(ChcDirectedGraph const & system);
+    VerificationResult solve(ChcDirectedGraph const & graph);
 
 private:
-    VerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
+    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
+    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
 };
 
 

--- a/src/engine/IMC.h
+++ b/src/engine/IMC.h
@@ -35,11 +35,14 @@ public:
         return VerificationResult(VerificationAnswer::UNKNOWN);
     }
 
-    VerificationResult solve(ChcDirectedGraph const & system);
+    VerificationResult solve(ChcDirectedGraph const & graph);
 
 private:
+    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
+    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
+
     InterpolantResult finiteRun(PTRef init, PTRef transition, PTRef query, int k);
-    VerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
+
     PTRef lastIterationInterpolant(MainSolver & solver, ipartitions_t const & mask);
     sstat checkItp(PTRef itp, PTRef itpsOld);
 };

--- a/src/engine/Kind.h
+++ b/src/engine/Kind.h
@@ -30,16 +30,15 @@ public:
 
     virtual VerificationResult solve(ChcDirectedHyperGraph const & graph) override;
 
-    VerificationResult solve(ChcDirectedGraph const & system);
+    VerificationResult solve(ChcDirectedGraph const & graph);
 
 private:
-    VerificationResult solveTransitionSystem(TransitionSystem const & system, ChcDirectedGraph const & graph);
+    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
+    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
 
-    ValidityWitness witnessFromForwardInduction(ChcDirectedGraph const & graph,
-                                                TransitionSystem const & transitionSystem, unsigned long k) const;
+    PTRef invariantFromForwardInduction(TransitionSystem const & transitionSystem, unsigned long k) const;
+    PTRef invariantFromBackwardInduction(TransitionSystem const & transitionSystem, unsigned long k) const;
 
-    ValidityWitness witnessFromBackwardInduction(ChcDirectedGraph const & graph,
-                                                 TransitionSystem const & transitionSystem, unsigned long k) const;
 };
 
 


### PR DESCRIPTION
This refactoring prepares the code for transformation of general linear CHC system to a transition system. The plan is that there will be no CHC graph corresponding to a transition system, but we go to directly to our inner TS representation. For this reason, we refactor the methods so they do not require both representation of a transition system.

To support witness production, we add a simple wrapper for a witness for our inner TS representation.