### PR TITLE
Fix issues with witnesses for IMC and some transformation passes

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -10,3 +10,5 @@ src/engine/Common.h
 
 src/transformers/SingleLoopTransformation.cc
 src/transformers/SingleLoopTransformation.h
+src/transformers/MultiEdgeMerger.cc
+src/transformers/MultiEdgeMerger.h

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -323,6 +323,11 @@ VerificationResult ChcInterpreterContext::solve(std::string engine_s, ChcDirecte
 void ChcInterpreterContext::validate(VerificationResult result, ChcDirectedHyperGraph const & originalGraph,
                                      bool validateWitness, bool printWitness, WitnessBackTranslator & translator) {
     result = translator.translate(std::move(result));
+    if (not result.hasWitness()) {
+        if (validateWitness) { std::cout << "Internal witness validation failed!" << std::endl; }
+        std::cerr << ";No witness has been computed.\n;Reason: " << result.getNoWitnessReason() << std::endl;
+        return;
+    }
     if (printWitness) { result.printWitness(std::cout, logic); }
     if (validateWitness) {
         auto validationResult = Validator(logic).validate(originalGraph, result);
@@ -377,7 +382,7 @@ void ChcInterpreterContext::interpretCheckSat() {
                 auto result = solve(engines[i], *hypergraph);
                 if (result.getAnswer() == VerificationAnswer::UNKNOWN) { exit(1); }
                 if (validateWitness || printWitness) {
-                    validate(result, *originalGraph, validateWitness, printWitness, *translator);
+                    validate(std::move(result), *originalGraph, validateWitness, printWitness, *translator);
                 }
                 return;
             }
@@ -408,7 +413,7 @@ void ChcInterpreterContext::interpretCheckSat() {
         return;
     }
     if (validateWitness || printWitness) {
-        validate(result, *originalGraph, validateWitness, printWitness, *translator);
+        validate(std::move(result), *originalGraph, validateWitness, printWitness, *translator);
     }
 }
 

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -9,6 +9,7 @@
 #include "Validator.h"
 #include "graph/ChcGraph.h"
 #include "graph/ChcGraphBuilder.h"
+#include "transformers/MultiEdgeMerger.h"
 #include "transformers/NodeEliminator.h"
 #include "transformers/RemoveUnreachableNodes.h"
 #include "transformers/SimpleChainSummarizer.h"
@@ -363,6 +364,8 @@ void ChcInterpreterContext::interpretCheckSat() {
     transformations.push_back(std::make_unique<SimpleChainSummarizer>());
     transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
     transformations.push_back(std::make_unique<SimpleNodeEliminator>());
+    transformations.push_back(std::make_unique<MultiEdgeMerger>());
+    // TODO: Try following MultiEdgeMerger by another round of SimpleChainSummarizer and/or SimpleNodeEliminator?
     auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));
     hypergraph = std::move(newGraph);
     // This if is needed to run the portfolio of multiple engines

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -104,7 +104,17 @@ public:
                                                 TransitionSystem const & transitionSystem, PTRef invariant);
 };
 
-struct NoWitness {};
+class NoWitness {
+    std::string reason;
+public:
+    explicit NoWitness(std::string_view reason) : reason(reason) {}
+
+    NoWitness() = default;
+    NoWitness(NoWitness &&) = default;
+    NoWitness & operator=(NoWitness &&) = default;
+
+    [[nodiscard]] std::string_view getReason() const { return reason; }
+};
 
 enum class VerificationAnswer : char {SAFE, UNSAFE, UNKNOWN};
 
@@ -119,6 +129,9 @@ public:
     VerificationResult(VerificationAnswer answer, InvalidityWitness invalidityWitness)
         : answer(answer), witness(std::move(invalidityWitness)) {}
 
+    VerificationResult(VerificationAnswer answer, NoWitness noWitness)
+        : answer(answer), witness(std::move(noWitness)) {}
+
     explicit VerificationResult(VerificationAnswer answer) : answer(answer), witness(NoWitness()) {}
 
     [[nodiscard]] VerificationAnswer getAnswer() const { return answer; }
@@ -127,6 +140,7 @@ public:
 
     [[nodiscard]] ValidityWitness const & getValidityWitness() const & { assert(answer == VerificationAnswer::SAFE); return std::get<ValidityWitness>(witness); }
     [[nodiscard]] InvalidityWitness const & getInvalidityWitness() const & { assert(answer == VerificationAnswer::UNSAFE); return std::get<InvalidityWitness>(witness); }
+    [[nodiscard]] std::string_view getNoWitnessReason() const & { assert(not hasWitness()); return std::get<NoWitness>(witness).getReason(); }
 
     ValidityWitness && getValidityWitness() && { assert(answer == VerificationAnswer::SAFE); return std::move(std::get<ValidityWitness>(witness)); }
     InvalidityWitness && getInvalidityWitness() && { assert(answer == VerificationAnswer::UNSAFE); return std::move(std::get<InvalidityWitness>(witness)); }

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -59,9 +59,12 @@ public:
         explicit Derivation(std::vector<DerivationStep> derivationSteps) : derivationSteps(std::move(derivationSteps)) {}
 
         using const_iterator = decltype(derivationSteps)::const_iterator;
+        using iterator = decltype(derivationSteps)::iterator;
 
         [[nodiscard]] const_iterator begin() const { return derivationSteps.begin(); }
         [[nodiscard]] const_iterator end() const { return derivationSteps.end(); }
+        [[nodiscard]] iterator begin() { return derivationSteps.begin(); }
+        [[nodiscard]] iterator end() { return derivationSteps.end(); }
 
     };
 
@@ -72,6 +75,7 @@ public:
     void setDerivation(Derivation derivation_) { derivation = std::move(derivation_); }
 
     [[nodiscard]] Derivation const & getDerivation() const { return derivation; }
+    [[nodiscard]] Derivation & getDerivation() { return derivation; }
 
     static InvalidityWitness fromErrorPath(ErrorPath const & errorPath, ChcDirectedGraph const & graph);
     static InvalidityWitness fromTransitionSystem(ChcDirectedGraph const & graph, std::size_t unrollings);

--- a/src/engine/Common.cc
+++ b/src/engine/Common.cc
@@ -4,7 +4,6 @@ VerificationResult solveTrivial(ChcDirectedGraph const & graph) {
     Logic & logic = graph.getLogic();
     // All edges should be between entry and exit, check if any of them has a satisfiable label
     auto edgeIds = graph.getEdges();
-    assert(edgeIds.size() <= 1); // Current preprocessing in TPA ensures that multiedges are replaced by single edge
     for (EId eid : edgeIds) {
         assert(graph.getSource(eid) == graph.getEntry());
         assert(graph.getTarget(eid) == graph.getExit());

--- a/src/engine/IMC.cc
+++ b/src/engine/IMC.cc
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Konstantin Britikov <britikovki@gmail.com>
+ * Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -33,9 +34,6 @@ VerificationResult IMC::solveTransitionSystem(ChcDirectedGraph const & graph) {
 
 TransitionSystemVerificationResult IMC::solveTransitionSystemInternal(TransitionSystem const & system) {
     std::size_t maxLoopUnrollings = std::numeric_limits<std::size_t>::max();
-    PTRef init = system.getInit();
-    PTRef query = system.getQuery();
-    PTRef transition = system.getTransition();
 
     SMTConfig config;
     const char * msg = "ok";
@@ -43,15 +41,14 @@ TransitionSystemVerificationResult IMC::solveTransitionSystemInternal(Transition
     config.setSimplifyInterpolant(4);
     TimeMachine tm{logic};
     MainSolver initSolver(logic, config, "IMC");
-    initSolver.insertFormula(init);
-    PTRef versionedQuery = tm.sendFlaThroughTime(query, 0);
-    initSolver.insertFormula(versionedQuery);
+    initSolver.insertFormula(system.getInit());
+    initSolver.insertFormula(system.getQuery());
     //if I /\ F is Satisfiable, return true
     if (initSolver.check() == s_True) {
         return TransitionSystemVerificationResult{VerificationAnswer::UNSAFE, 0u};
     }
     for (uint32_t k = 1; k < maxLoopUnrollings; ++k) {
-        InterpolantResult res = finiteRun(init, transition, query, k);
+        InterpolantResult res = finiteRun(system, k);
         if (res.result == l_True) {
             return TransitionSystemVerificationResult{VerificationAnswer::UNSAFE, static_cast<std::size_t>(res.depth)};
         }
@@ -63,36 +60,37 @@ TransitionSystemVerificationResult IMC::solveTransitionSystemInternal(Transition
 }
 
 //procedure FiniteRun(M=(I,T,F), k>0)
-IMC::InterpolantResult IMC::finiteRun(PTRef init, PTRef transition, PTRef query, int k) {
+IMC::InterpolantResult IMC::finiteRun(TransitionSystem const & ts, unsigned k) {
+    assert(k > 0);
     SMTConfig config;
     const char * msg = "ok";
     config.setOption(SMTConfig::o_produce_inter, SMTOption(true), msg);
     config.setSimplifyInterpolant(4);
     TimeMachine tm{logic};
-    PTRef movingInit = init;
-    int iter = 0;
+    PTRef movingInit = ts.getInit();
+    unsigned iter = 0;
     // while true
     while (true) {
         MainSolver solver(logic, config, "IMC");
         //A = CNF(PREF1(M'), U1)
-        PTRef A = logic.mkAnd(movingInit, tm.sendFlaThroughTime(transition, iter));
+        PTRef A = logic.mkAnd(movingInit, tm.sendFlaThroughTime(ts.getTransition(), iter));
         solver.insertFormula(A);
         //B = CNF(SUFFk(M'), U2)
-        PTRef B = tm.sendFlaThroughTime(query, iter + k);
-        for (int i = iter + 1; i < iter + k; ++i) {
-            B = logic.mkAnd(B, tm.sendFlaThroughTime(transition, i));
+        PTRef B = tm.sendFlaThroughTime(ts.getQuery(), iter + k);
+        for (unsigned i = iter + 1; i < iter + k; ++i) {
+            B = logic.mkAnd(B, tm.sendFlaThroughTime(ts.getTransition(), i));
         }
         solver.insertFormula(B);
         // Run SAT on A U B.
         auto res = solver.check();
         // if A U B is satisfiable
         if (res == s_True) {
-            if (movingInit == init) {
+            if (movingInit == ts.getInit()) {
                 // if R=I return True
-                return InterpolantResult{l_True, iter + k, init};
+                return InterpolantResult{l_True, iter + k, PTRef_Undef};
             } else {
                 // else Abort
-                return InterpolantResult{l_Undef, iter + k, init};
+                return InterpolantResult{l_Undef, iter + k, PTRef_Undef};
             }
             // else if A U B is unsat
         } else {
@@ -105,7 +103,9 @@ IMC::InterpolantResult IMC::finiteRun(PTRef init, PTRef transition, PTRef query,
             movingInit = tm.sendFlaThroughTime(movingInit, 1);
             //if R' => R return False(if R' /\ not R returns True)
             if (checkItp(itp, movingInit) == s_False) {
-                return InterpolantResult{l_False, iter + k, tm.sendFlaThroughTime(movingInit, -iter - 1)};
+                PTRef inductiveInvariant = tm.sendFlaThroughTime(movingInit, -iter - 1);
+                PTRef finalInductiveInvariant = computeFinalInductiveInvariant(inductiveInvariant, k, ts);
+                return InterpolantResult{l_False, iter + k, finalInductiveInvariant};
             }
             // let R = R\/R'
             movingInit = logic.mkOr(movingInit, itp);
@@ -128,4 +128,28 @@ sstat IMC::checkItp(PTRef itp, PTRef itpsOld) {
     MainSolver itpSolver(logic, itp_config, "Interpolant");
     itpSolver.insertFormula(cmp);
     return itpSolver.check();
+}
+
+/**
+ * In our current implementation, we find an inductive invariant that is not necessarily safe, we only know that it
+ * cannot reach Bad in k steps. However, we also know that Bad cannot be truly reachable, otherwise the path would have
+ * been discovered earlier.
+ * What we definitely know is that Inv and ~Bad is safe k-inductive invariant. Since Inv is inductive, it follows that
+ * after k steps, we stay in Inv, but we also know we cannot reach Bad, thus we reach Inv and ~Bad again.
+ *
+ * @param inductiveInvariant an inductive invariant of the system
+ * @param k number of steps for which Bad in not reachable from the invariant
+ * @param ts transition system
+ * @return safe inductive invariant of the system
+ */
+PTRef IMC::computeFinalInductiveInvariant(PTRef inductiveInvariant, unsigned k, TransitionSystem const & ts) {
+    SMTConfig config;
+    MainSolver solver(logic, config, "");
+    solver.insertFormula(inductiveInvariant);
+    solver.insertFormula(ts.getQuery());
+    auto res = solver.check();
+    if (res == s_False) { return inductiveInvariant; }
+    // Otherwise compute safe inductive invariant from k-inductive invariant
+    PTRef kinductive = logic.mkAnd(inductiveInvariant, logic.mkNot(ts.getQuery()));
+    return kinductiveToInductive(kinductive, k, ts);
 }

--- a/src/engine/IMC.h
+++ b/src/engine/IMC.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Konstantin Britikov <britikovki@gmail.com>
+ * Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -17,7 +18,7 @@ class IMC : public Engine {
 public:
     struct InterpolantResult{
         lbool result;
-        int depth;
+        unsigned depth;
         PTRef interpolant;
     };
 
@@ -41,7 +42,9 @@ private:
     VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
     TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
 
-    InterpolantResult finiteRun(PTRef init, PTRef transition, PTRef query, int k);
+    InterpolantResult finiteRun(TransitionSystem const & ts, unsigned k);
+
+    PTRef computeFinalInductiveInvariant(PTRef inductiveInvariant, unsigned k, TransitionSystem const & ts);
 
     PTRef lastIterationInterpolant(MainSolver & solver, ipartitions_t const & mask);
     sstat checkItp(PTRef itp, PTRef itpsOld);

--- a/src/engine/IMC.h
+++ b/src/engine/IMC.h
@@ -15,16 +15,15 @@ class IMC : public Engine {
     Logic & logic;
 //    Options const & options;
     int verbosity = 0;
-public:
-    struct InterpolantResult{
-        lbool result;
-        unsigned depth;
-        PTRef interpolant;
-    };
+    bool computeWitness = false;
 
+public:
     IMC(Logic & logic, Options const & options) : logic(logic) {
         if (options.hasOption(Options::VERBOSE)) {
             verbosity = std::stoi(options.getOption(Options::VERBOSE));
+        }
+        if (options.hasOption(Options::COMPUTE_WITNESS)) {
+            computeWitness = options.getOption(Options::COMPUTE_WITNESS) == "true";
         }
     }
 
@@ -42,11 +41,10 @@ private:
     VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
     TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
 
-    InterpolantResult finiteRun(TransitionSystem const & ts, unsigned k);
+    TransitionSystemVerificationResult finiteRun(TransitionSystem const & ts, unsigned k);
 
     PTRef computeFinalInductiveInvariant(PTRef inductiveInvariant, unsigned k, TransitionSystem const & ts);
 
-    PTRef lastIterationInterpolant(MainSolver & solver, ipartitions_t const & mask);
     sstat checkItp(PTRef itp, PTRef itpsOld);
 };
 

--- a/src/engine/Kind.cc
+++ b/src/engine/Kind.cc
@@ -20,7 +20,7 @@ VerificationResult Kind::solve(ChcDirectedHyperGraph const & graph) {
     if (transformedGraph->isNormalGraph()) {
         auto normalGraph = transformedGraph->toNormalGraph();
         auto res = solve(*normalGraph);
-        return computeWitness ? translator->translate(std::move(res)) : res;
+        return computeWitness ? translator->translate(std::move(res)) : std::move(res);
     }
     return VerificationResult(VerificationAnswer::UNKNOWN);
 }

--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -51,7 +51,7 @@ VerificationResult TPAEngine::solve(ChcDirectedHyperGraph const & graph) {
     if (transformedGraph->isNormalGraph()) {
         auto normalGraph = transformedGraph->toNormalGraph();
         auto res = solve(*normalGraph);
-        return options.hasOption(Options::COMPUTE_WITNESS) ? translator->translate(std::move(res)) : res;
+        return options.hasOption(Options::COMPUTE_WITNESS) ? translator->translate(std::move(res)) : std::move(res);
     }
     return VerificationResult(VerificationAnswer::UNKNOWN);
 }

--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -410,11 +410,12 @@ ChcDirectedHyperGraph::VertexContractionResult ChcDirectedHyperGraph::contractVe
     std::transform(outgoingEdges.begin(), outgoingEdges.end(), std::back_inserter(result.outgoing), [this](EId eid) {
         return this->getEdge(eid);
     });
-    std::size_t incomingIndex = 0;
-    for (EId incomingId : incomingEdges) {
+    for (std::size_t incomingIndex = 0; incomingIndex < incomingEdges.size(); ++incomingIndex) {
+        EId incomingId = incomingEdges[incomingIndex];
         if (getSources(incomingId).size() > 1) { throw std::logic_error("Unable to contract vertex with hyperedge!"); }
-        std::size_t outgoingIndex = 0;
-        for (EId outgoingId : outgoingEdges) {
+
+        for (std::size_t outgoingIndex = 0; outgoingIndex < outgoingEdges.size(); ++outgoingIndex) {
+            EId outgoingId = outgoingEdges[outgoingIndex];
             if (getSources(outgoingId).size() > 1) { throw std::logic_error("Unable to contract vertex with hyperedge!"); }
             auto replacingEdge = mergeEdges({incomingId, outgoingId});
             result.replacing.emplace_back(std::move(replacingEdge), std::make_pair(incomingIndex, outgoingIndex));

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -272,8 +272,9 @@ public:
     }
     DirectedHyperEdge contractTrivialChain(std::vector<EId> const & trivialChain);
     VertexContractionResult contractVertex(SymRef sym);
-    // FIXME: Return more information about what happened
-    bool mergeMultiEdges();
+
+    using MergedEdges = std::vector<std::pair<std::vector<DirectedHyperEdge>, DirectedHyperEdge>>;
+    MergedEdges mergeMultiEdges();
 
     template<typename TAction>
     void forEachEdge(TAction action) const {

--- a/src/transformers/MultiEdgeMerger.cc
+++ b/src/transformers/MultiEdgeMerger.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -7,17 +7,74 @@
 #include "MultiEdgeMerger.h"
 
 Transformer::TransformationResult MultiEdgeMerger::transform(std::unique_ptr<ChcDirectedHyperGraph> graph) {
-    auto backtranslator = std::make_unique<BackTranslator>();
-    backtranslator->somethingChanged = graph->mergeMultiEdges();
+    auto backtranslator = std::make_unique<BackTranslator>(graph->getLogic(), graph->predicateRepresentation());
+    backtranslator->mergedEdges = graph->mergeMultiEdges();
     return {std::move(graph), std::move(backtranslator)};
 }
 
 InvalidityWitness MultiEdgeMerger::BackTranslator::translate(InvalidityWitness witness) {
-    if (somethingChanged) {
-        return InvalidityWitness();
-    } else {
+    if (mergedEdges.empty()) {
         return witness;
     }
+    auto & derivation = witness.getDerivation();
+    for (auto & step : derivation) {
+        auto eid = step.clauseId;
+        auto it = std::find_if(mergedEdges.begin(), mergedEdges.end(), [eid](auto const & mergedEntry) {
+           return mergedEntry.second.id == eid;
+        });
+        if (it == mergedEdges.end()) { continue; }
+        auto const& replacedEdges = it->first;
+        auto const& replacingEdge = it->second;
+        // Figure out which of the replaced edges can be used to derive the same fact
+        auto model = [&]() -> std::unique_ptr<Model> {
+            ModelBuilder builder(logic);
+            // collect values from the derived fact
+            auto targetVertex = replacingEdge.to;
+            assert(predicateRepresentation.hasRepresentationFor(targetVertex));
+            PTRef targetTerm = predicateRepresentation.getTargetTermFor(targetVertex);
+            PTRef derivedFact = step.derivedFact;
+            assert(logic.getPterm(targetTerm).size() == logic.getPterm(derivedFact).size());
+            assert(logic.getSymRef(targetTerm) == targetVertex and logic.getSymRef(derivedFact) == targetVertex);
+            auto argsCount = logic.getPterm(targetTerm).size();
+            for (auto i = 0u; i < argsCount; ++i) {
+                builder.addVarValue(logic.getPterm(targetTerm)[i], logic.getPterm(derivedFact)[i]);
+            }
+            // and collect values from the premise as well
+            auto const& premises = step.premises;
+            assert(premises.size() == 1); // TODO: Generalize this when we generalize MultiEdgeMerge to HyperEdges
+            auto const& premiseStep = derivation[premises[0]];
+            auto sourceVertex = replacingEdge.from[0];
+            PTRef premise = premiseStep.derivedFact;
+            PTRef sourceTerm = predicateRepresentation.getSourceTermFor(sourceVertex);
+            assert(logic.getPterm(sourceTerm).size() == logic.getPterm(premise).size());
+            assert(logic.getSymRef(sourceTerm) == sourceVertex and logic.getSymRef(premise) == sourceVertex);
+            argsCount = logic.getPterm(sourceTerm).size();
+            for (auto i = 0u; i < argsCount; ++i) {
+                builder.addVarValue(logic.getPterm(sourceTerm)[i], logic.getPterm(premise)[i]);
+            }
+            return builder.build();
+        }();
+
+        auto chosenEdgeIndex = [&]() -> std::optional<std::size_t> {
+            for (std::size_t i = 0u; i < replacedEdges.size(); ++i) {
+                if (model->evaluate(replacedEdges[i].fla.fla) == logic.getTerm_true()) { return i; }
+            }
+            // No edge evaluate to true, try to find one with satisfiable label
+            for (std::size_t i = 0u; i < replacedEdges.size(); ++i) {
+                PTRef simplifiedLabel = model->evaluate(replacedEdges[i].fla.fla);
+                if (simplifiedLabel == logic.getTerm_false()) { continue; }
+                SMTConfig config;
+                MainSolver solver(logic, config, "");
+                solver.insertFormula(simplifiedLabel);
+                if (solver.check() == s_True) { return i; }
+            }
+            return {};
+        }();
+        if (not chosenEdgeIndex.has_value()) { return InvalidityWitness{}; } // TODO: Change API to allow return NoWitness with reason
+        auto const & chosenEdge = replacedEdges[chosenEdgeIndex.value()];
+        step.clauseId = chosenEdge.id;
+    }
+    return std::move(witness);
 }
 
 ValidityWitness MultiEdgeMerger::BackTranslator::translate(ValidityWitness witness) {

--- a/src/transformers/MultiEdgeMerger.cc
+++ b/src/transformers/MultiEdgeMerger.cc
@@ -13,25 +13,23 @@ Transformer::TransformationResult MultiEdgeMerger::transform(std::unique_ptr<Chc
 }
 
 InvalidityWitness MultiEdgeMerger::BackTranslator::translate(InvalidityWitness witness) {
-    if (mergedEdges.empty()) {
-        return witness;
-    }
+    if (mergedEdges.empty()) { return witness; }
     auto & derivation = witness.getDerivation();
     for (auto & step : derivation) {
         auto eid = step.clauseId;
-        auto it = std::find_if(mergedEdges.begin(), mergedEdges.end(), [eid](auto const & mergedEntry) {
-           return mergedEntry.second.id == eid;
-        });
+        auto it = std::find_if(mergedEdges.begin(), mergedEdges.end(),
+                               [eid](auto const & mergedEntry) { return mergedEntry.second.id == eid; });
         if (it == mergedEdges.end()) { continue; }
-        auto const& replacedEdges = it->first;
-        auto const& replacingEdge = it->second;
+        auto const & replacedEdges = it->first;
+        auto const & replacingEdge = it->second;
         // Figure out which of the replaced edges can be used to derive the same fact
         TermUtils utils(logic);
         TermUtils::substitutions_map subst;
         { // build the substitution map
             auto fillVariables = [&](PTRef derivedFact, PTRef normalizedPredicate) {
                 assert(logic.getSymRef(derivedFact) == logic.getSymRef(normalizedPredicate));
-                auto const & term = logic.getPterm(derivedFact); (void) term;
+                auto const & term = logic.getPterm(derivedFact);
+                (void)term;
                 assert(std::all_of(term.begin(), term.end(), [&](PTRef arg) { return logic.isConstant(arg); }));
                 utils.mapFromPredicate(normalizedPredicate, derivedFact, subst);
             };
@@ -44,9 +42,9 @@ InvalidityWitness MultiEdgeMerger::BackTranslator::translate(InvalidityWitness w
             assert(logic.getSymRef(targetTerm) == targetVertex and logic.getSymRef(derivedFact) == targetVertex);
             fillVariables(derivedFact, targetTerm);
             // and collect values from the premise as well
-            auto const& premises = step.premises;
+            auto const & premises = step.premises;
             assert(premises.size() == 1); // TODO: Generalize this when we generalize MultiEdgeMerge to HyperEdges
-            auto const& premiseStep = derivation[premises[0]];
+            auto const & premiseStep = derivation[premises[0]];
             auto sourceVertex = replacingEdge.from[0];
             PTRef premise = premiseStep.derivedFact;
             PTRef sourceTerm = predicateRepresentation.getSourceTermFor(sourceVertex);
@@ -72,7 +70,9 @@ InvalidityWitness MultiEdgeMerger::BackTranslator::translate(InvalidityWitness w
             }
             return {};
         }();
-        if (not chosenEdgeIndex.has_value()) { return InvalidityWitness{}; } // TODO: Change API to allow return NoWitness with reason
+        if (not chosenEdgeIndex.has_value()) {
+            return InvalidityWitness{}; // TODO: Change API to allow return NoWitness with reason
+        }
         auto const & chosenEdge = replacedEdges[chosenEdgeIndex.value()];
         step.clauseId = chosenEdge.id;
     }

--- a/src/transformers/MultiEdgeMerger.h
+++ b/src/transformers/MultiEdgeMerger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2023, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -15,11 +15,18 @@ public:
 
     class BackTranslator : public WitnessBackTranslator {
     public:
+        BackTranslator(Logic & logic, NonlinearCanonicalPredicateRepresentation predicateRepresentation)
+            : logic(logic), predicateRepresentation(std::move(predicateRepresentation)) {}
+
         InvalidityWitness translate(InvalidityWitness witness) override;
 
         ValidityWitness translate(ValidityWitness witness) override;
 
-        bool somethingChanged {false};
+        using MergedEdges = ChcDirectedHyperGraph::MergedEdges;
+
+        MergedEdges mergedEdges {};
+        Logic & logic;
+        NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     };
 };
 

--- a/src/transformers/MultiEdgeMerger.h
+++ b/src/transformers/MultiEdgeMerger.h
@@ -24,11 +24,10 @@ public:
 
         using MergedEdges = ChcDirectedHyperGraph::MergedEdges;
 
-        MergedEdges mergedEdges {};
+        MergedEdges mergedEdges{};
         Logic & logic;
         NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     };
 };
 
-
-#endif //GOLEM_MULTIEDGEMERGER_H
+#endif // GOLEM_MULTIEDGEMERGER_H

--- a/src/transformers/SingleLoopTransformation.cc
+++ b/src/transformers/SingleLoopTransformation.cc
@@ -257,7 +257,8 @@ SingleLoopTransformation::WitnessBackTranslator::translateInvariant(PTRef induct
         bool hasAlienVariable = std::any_of(allVars.begin(), allVars.end(),
                                             [&](PTRef var) { return vertexVars.find(var) == vertexVars.end(); });
         if (hasAlienVariable) {
-            return NoWitness{"Could not backtranslate validity witness in single-loop transformation: Predicate interpretation contains alien variable"};
+            return NoWitness{"Could not backtranslate validity witness in single-loop transformation: Predicate "
+                             "interpretation contains alien variable"};
         } // TODO: Figure out a way to deal with this situation properly
         // No alien variable, we can translate the invariant using predicate's variables
         TermUtils::substitutions_map varSubstitutions;

--- a/src/transformers/SingleLoopTransformation.h
+++ b/src/transformers/SingleLoopTransformation.h
@@ -70,9 +70,11 @@ public:
         VerificationResult translate(TransitionSystemVerificationResult result);
 
     private:
-        InvalidityWitness translateErrorPath(std::size_t unrolling);
+        template<typename T> using ErrorOr = std::variant<NoWitness, T>;
 
-        ValidityWitness translateInvariant(PTRef inductiveInvariant);
+        ErrorOr<InvalidityWitness> translateErrorPath(std::size_t unrolling);
+
+        ErrorOr<ValidityWitness> translateInvariant(PTRef inductiveInvariant);
 
         std::set<PTRef> getVarsForVertex(SymRef vertex) const;
     };

--- a/src/transformers/Transformer.h
+++ b/src/transformers/Transformer.h
@@ -19,7 +19,7 @@ public:
     virtual ValidityWitness translate(ValidityWitness witness) = 0;
     virtual ~WitnessBackTranslator() = default;
     VerificationResult translate(VerificationResult && result) {
-        if (not result.hasWitness()) { return result; }
+        if (not result.hasWitness()) { return std::move(result); }
         auto answer = result.getAnswer();
         switch (answer) {
             case VerificationAnswer::SAFE:
@@ -27,7 +27,7 @@ public:
             case VerificationAnswer::UNSAFE:
                 return {answer, translate(std::move(result).getInvalidityWitness())};
             case VerificationAnswer::UNKNOWN:
-                return result;
+                return std::move(result);
         }
         throw std::logic_error("Unreachable");
     }

--- a/test/test_Spacer.cc
+++ b/test/test_Spacer.cc
@@ -12,9 +12,9 @@ class Spacer_LRA_Test : public LRAEngineTest {
 
 TEST_F(Spacer_LRA_Test, test_TransitionSystem)
 {
-	SymRef inv_sym = mkPredicateSymbol("Inv", {realSort()});
-	PTRef inv = instantiatePredicate(inv_sym, {x});
-	PTRef invp = instantiatePredicate(inv_sym, {xp});
+    SymRef inv_sym = mkPredicateSymbol("Inv", {realSort()});
+    PTRef inv = instantiatePredicate(inv_sym, {x});
+    PTRef invp = instantiatePredicate(inv_sym, {xp});
     std::vector<ChClause> clauses{
         { // x' = 0 => Inv(x')
             ChcHead{UninterpretedPredicate{invp}},
@@ -30,7 +30,7 @@ TEST_F(Spacer_LRA_Test, test_TransitionSystem)
         }
     };
 	
-	Spacer engine(*logic, options);
+    Spacer engine(*logic, options);
     solveSystem(clauses, engine, VerificationAnswer::SAFE);
 }
 

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -5,11 +5,17 @@
  */
 
 #include <gtest/gtest.h>
+#include "TestTemplate.h"
+
 #include "graph/ChcGraphBuilder.h"
 #include "transformers/SimpleChainSummarizer.h"
 #include "transformers/NodeEliminator.h"
+#include "transformers/MultiEdgeMerger.h"
 #include "Validator.h"
 #include "engine/Spacer.h"
+
+class Transformer_New_Test : public LIAEngineTest {
+};
 
 class Transformer_test : public ::testing::Test {
 protected:
@@ -374,4 +380,54 @@ TEST_F(Transformer_test, test_NodeEliminator_PredicateWithoutVariables) {
     Validator validator(logic);
     auto res = validator.validate(originalGraph, VerificationResult(VerificationAnswer::SAFE, witness));
     ASSERT_EQ(res, Validator::Result::VALIDATED);
+}
+
+TEST_F(Transformer_New_Test, test_MultiEdgeMerger_SimpleUnsafe) {
+    Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {intSort(), intSort()});
+    PTRef current = instantiatePredicate(s1, {x,y});
+    PTRef next = instantiatePredicate(s1, {xp,yp});
+    PTRef val = logic->mkIntConst(2);
+    // x = 0 and y = 0 => S1(x,y)
+    // S1(x,y) and x' = x + 1 => S1(x',y)
+    // S1(x,y) and y' = y + 1 => S1(x,y')
+    // S1(x,y) and y > 2 and x > 2 => false
+
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, zero), logic->mkEq(yp, zero))}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, logic->mkPlus(x, one)), logic->mkEq(yp, y))}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(yp, logic->mkPlus(y, one)), logic->mkEq(xp, x))}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkAnd(logic->mkGt(y, val), logic->mkGt(x, val))}, {UninterpretedPredicate{current}}}
+        }};
+
+    for (auto const & clause : clauses) { system.addClause(clause); }
+
+    Logic & logic = *this->logic;
+    auto normalizedSystem = Normalizer(logic).normalize(system);
+    auto hyperGraph = ChcGraphBuilder(logic).buildGraph(normalizedSystem);
+    auto originalGraph = *hyperGraph;
+    MultiEdgeMerger transformation;
+    auto [transformedGraph, translator] = transformation.transform(std::move(hyperGraph));
+    ASSERT_EQ(transformedGraph->getEdges().size(), 3);
+    auto res = Spacer(logic, options).solve(*transformedGraph);
+    auto answer = res.getAnswer();
+    ASSERT_EQ(answer, VerificationAnswer::UNSAFE);
+    auto translatedWitness = translator->translate(res.getInvalidityWitness());
+    VerificationResult translatedResult(VerificationAnswer::UNSAFE, translatedWitness);
+    Validator validator(logic);
+    EXPECT_EQ(validator.validate(originalGraph, res), Validator::Result::NOT_VALIDATED);
+    EXPECT_EQ(validator.validate(originalGraph, translatedResult), Validator::Result::VALIDATED);
 }


### PR DESCRIPTION
The main change here is a fix to IMC to produce correct inductive invariant for the given transition system.
The problem was that when IMC detects a fixed point, the state formula is an inductive invariant, but it is not necessarily safe on its own. We only know that it cannot reach bad states in `k` steps where `k` is the current value of the parameter of the procedure `finiteRun`.
While this is sound, because it still guarantees that bad states are unreachable, the witness has to be different.
For now I only was able to prove that the fixed point conjoined with the negation of bad states is k-inductive.
(It would be good to try to improve on this to avoid k-induction).

While working on this, I discovered a bug in `BackTranslator` for `NodeEliminator` which was not tracking the necessary information correctly and this resulted in incorrect final proofs.

Additionally, this PR adds the backtranslator for `MultiEdgeMerger` (which merges multiple edges with the same source and target to a single edge). This enables us to use `MultiEdgeMerger` for the preprocessing for all engines. This enabled `IMC` to solve more benchmarks and compute witnesses correctly for all UNSAT cases which it was  able to solve. 