### PR TITLE
TPA: Fix computation of explanations

### DIFF
--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -63,7 +63,10 @@ struct SafetyExplanation {
     TransitionInvariantType invariantType{TransitionInvariantType::NONE};
     TPAType relationType{TPAType::LESS_THAN};
     FixedPointType fixedPointType{FixedPointType::LEFT};
-    unsigned power{0};
+    PTRef safeTransitionInvariant{PTRef_Undef};
+
+    /** the transition invariant is k-inductive for k = 2^{inductivnessPowerExponent}*/
+    uint32_t inductivnessPowerExponent{0};
 };
 
 struct ReachedStates {
@@ -113,6 +116,11 @@ public:
     PTRef getTransitionRelation() const;
     PTRef getQuery() const;
 
+    /**
+     * After the current system has been proven safe, this method can be used to extract superset of initial states that
+     * are also safe, given the explanation found by the algorithm.
+     * @return superset of initial states that are still safe
+     */
     PTRef getSafetyExplanation() const;
     PTRef getReachedStates() const;
     unsigned getTransitionStepCount() const;


### PR DESCRIPTION
In the current version method TPABase::getSafetyExplanation does not work correctly if the safety has been proven using (left or right) transition invariants collected in the Houdini check.

The problem is that the method in the current version still relies on the information stored in explanation.power, but this information is not (and cannot) be filled in the case mentioned above.

The proposed solution is to store directly the transition invariant in the explanation, instead of implicitly relying on the assumption that the invariant is one of the abstract transitions.