### PR TITLE
Everywhere: Simplify typical use of SMT solver

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -14,3 +14,6 @@ src/transformers/SingleLoopTransformation.cc
 src/transformers/SingleLoopTransformation.h
 src/transformers/TrivialEdgePruner.cc
 src/transformers/TrivialEdgePruner.h
+
+src/utils/SmtSolver.h
+src/utils/SmtSolver.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(golem_lib
     PRIVATE transformers/SingleLoopTransformation.cc
     PRIVATE transformers/TransformationPipeline.cc
     PRIVATE transformers/TrivialEdgePruner.cc
+    PRIVATE utils/SmtSolver.cc
     )
 
 target_include_directories(golem_lib PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/include)

--- a/src/QuantifierElimination.cc
+++ b/src/QuantifierElimination.cc
@@ -1,12 +1,14 @@
-//
-// Created by Martin Blicha on 12.06.21.
-//
+/*
+* Copyright (c) 2021-2023, Martin Blicha <martin.blicha@gmail.com>
+*
+* SPDX-License-Identifier: MIT
+*/
 
 #include "QuantifierElimination.h"
 
 #include "ModelBasedProjection.h"
 #include "TermUtils.h"
-
+#include "utils/SmtSolver.h"
 
 PTRef QuantifierElimination::keepOnly(PTRef fla, const vec<PTRef> & varsToKeep) {
     auto allVars = TermUtils(logic).getVars(fla);
@@ -31,10 +33,8 @@ PTRef QuantifierElimination::eliminate(PTRef fla, vec<PTRef> const & vars) {
     fla = TermUtils(logic).toNNF(fla);
     vec<PTRef> projections;
 
-    SMTConfig config;
-    const char* msg = "ok";
-    config.setOption(SMTConfig::o_produce_models, SMTOption(true), msg);
-    MainSolver solver(logic, config, "QE solver");
+    SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+    auto & solver = solverWrapper.getCoreSolver();
     solver.insertFormula(fla);
     while(true) {
         auto res = solver.check();

--- a/src/Witnesses.cc
+++ b/src/Witnesses.cc
@@ -7,6 +7,7 @@
 #include "Witnesses.h"
 
 #include "TransformationUtils.h"
+#include "utils/SmtSolver.h"
 
 void VerificationResult::printWitness(std::ostream & out, Logic & logic) const {
     if (not hasWitness()) { return; }
@@ -34,8 +35,8 @@ InvalidityWitness InvalidityWitness::fromErrorPath(ErrorPath const & errorPath, 
     auto edgeIds = path.getEdges();
     // Compute model for the error path
     auto model = [&]() {
-        SMTConfig config;
-        MainSolver solver(logic, config, "path_solver");
+        SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+        auto & solver = solverWrapper.getCoreSolver();
         for (std::size_t i = 0; i < edgeIds.size(); ++i) {
             PTRef fla = graph.getEdgeLabel(edgeIds[i]);
             fla = TimeMachine(logic).sendFlaThroughTime(fla, i);

--- a/src/engine/Bmc.cc
+++ b/src/engine/Bmc.cc
@@ -7,9 +7,11 @@
 #include "Bmc.h"
 
 #include "Common.h"
+
 #include "TermUtils.h"
 #include "TransformationUtils.h"
 #include "transformers/SingleLoopTransformation.h"
+#include "utils/SmtSolver.h"
 
 VerificationResult BMC::solve(ChcDirectedGraph const & graph) {
     if (isTrivial(graph)) {
@@ -38,8 +40,8 @@ TransitionSystemVerificationResult BMC::solveTransitionSystemInternal(Transition
     PTRef query = system.getQuery();
     PTRef transition = system.getTransition();
 
-    SMTConfig config;
-    MainSolver solver(logic, config, "BMC");
+    SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::NONE);
+    auto & solver = solverWrapper.getCoreSolver();
 //    std::cout << "Adding initial states: " << logic.pp(init) << std::endl;
     solver.insertFormula(init);
     { // Check for system with empty initial states

--- a/src/engine/Common.cc
+++ b/src/engine/Common.cc
@@ -1,5 +1,7 @@
 #include "Common.h"
 
+#include "utils/SmtSolver.h"
+
 VerificationResult solveTrivial(ChcDirectedGraph const & graph) {
     Logic & logic = graph.getLogic();
     // All edges should be between entry and exit, check if any of them has a satisfiable label
@@ -9,8 +11,8 @@ VerificationResult solveTrivial(ChcDirectedGraph const & graph) {
         assert(graph.getTarget(eid) == graph.getExit());
         PTRef label = graph.getEdgeLabel(eid);
         if (label == logic.getTerm_false()) { continue; }
-        SMTConfig config;
-        MainSolver solver(logic, config, "solver");
+        SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::NONE);
+        auto & solver = solverWrapper.getCoreSolver();
         solver.insertFormula(label);
         auto res = solver.check();
         if (res == s_False) {

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -1,6 +1,8 @@
-//
-// Created by Martin Blicha on 17.07.20.
-//
+/*
+* Copyright (c) 2020-2023, Martin Blicha <martin.blicha@gmail.com>
+*
+* SPDX-License-Identifier: MIT
+*/
 
 #ifndef OPENSMT_ENGINE_H
 #define OPENSMT_ENGINE_H
@@ -9,7 +11,6 @@
 #include "Options.h"
 #include "graph/ChcGraph.h"
 
-#include "osmt_solver.h"
 #include "osmt_terms.h"
 
 #include <memory>

--- a/src/transformers/CommonUtils.cc
+++ b/src/transformers/CommonUtils.cc
@@ -6,6 +6,8 @@
 
 #include "CommonUtils.h"
 
+#include "utils/SmtSolver.h"
+
 using DerivationStep = InvalidityWitness::Derivation::DerivationStep;
 
 InvalidityWitness::Derivation replaceSummarizingStep(
@@ -47,8 +49,9 @@ InvalidityWitness::Derivation replaceSummarizingStep(
     const PTRef targetPredicate = LinearPredicateVersioning(logic).sendPredicateThroughTime(versionPredicate(replacingEdge.to),simpleChain.size());
     utils.mapFromPredicate(targetPredicate, summarizedStep.derivedFact, subst);
     utils.mapFromPredicate(sourcePredicate, derivation[summarizedStep.premises.front()].derivedFact, subst);
-    SMTConfig config;
-    MainSolver solver(logic, config, "");
+
+    SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+    auto & solver = solverWrapper.getCoreSolver();
     solver.insertFormula(logic.mkAnd(std::move(edgeConstraints)));
     for (auto const & [var,value] : subst) {
         assert(logic.isVar(var) and logic.isConstant(value));

--- a/src/transformers/MultiEdgeMerger.cc
+++ b/src/transformers/MultiEdgeMerger.cc
@@ -6,6 +6,8 @@
 
 #include "MultiEdgeMerger.h"
 
+#include "utils/SmtSolver.h"
+
 Transformer::TransformationResult MultiEdgeMerger::transform(std::unique_ptr<ChcDirectedHyperGraph> graph) {
     auto backtranslator = std::make_unique<BackTranslator>(graph->getLogic(), graph->predicateRepresentation());
     backtranslator->mergedEdges = graph->mergeMultiEdges();
@@ -63,8 +65,8 @@ InvalidityWitness MultiEdgeMerger::BackTranslator::translate(InvalidityWitness w
             // No edge evaluate to true, try to find one with satisfiable label
             for (std::size_t i = 0u; i < evaluatedLabels.size(); ++i) {
                 if (evaluatedLabels[i] == logic.getTerm_false()) { continue; }
-                SMTConfig config;
-                MainSolver solver(logic, config, "");
+                SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::NONE);
+                auto & solver = solverWrapper.getCoreSolver();
                 solver.insertFormula(evaluatedLabels[i]);
                 if (solver.check() == s_True) { return i; }
             }

--- a/src/transformers/SingleLoopTransformation.cc
+++ b/src/transformers/SingleLoopTransformation.cc
@@ -7,6 +7,7 @@
 #include "SingleLoopTransformation.h"
 
 #include "TransformationUtils.h"
+#include "utils/SmtSolver.h"
 
 namespace {
 using LocationVarMap = SingleLoopTransformation::LocationVarMap;
@@ -162,8 +163,8 @@ SingleLoopTransformation::WitnessBackTranslator::translateErrorPath(std::size_t 
     // We need to get the CEX path, which will define the locations in the graph
     Logic & logic = graph.getLogic();
     TimeMachine tm(logic);
-    SMTConfig config;
-    MainSolver solver(logic, config, "CEX");
+    SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+    auto & solver = solverWrapper.getCoreSolver();
     solver.insertFormula(transitionSystem.getInit());
     PTRef transition = transitionSystem.getTransition();
     for (auto i = 0u; i < unrolling; ++i) {

--- a/src/transformers/TrivialEdgePruner.cc
+++ b/src/transformers/TrivialEdgePruner.cc
@@ -6,6 +6,8 @@
 
 #include "TrivialEdgePruner.h"
 
+#include "utils/SmtSolver.h"
+
 Transformer::TransformationResult TrivialEdgePruner::transform(std::unique_ptr<ChcDirectedHyperGraph> graph) {
     std::vector<EId> directEdges;
     graph->forEachEdge([&](auto const & edge) {
@@ -17,8 +19,8 @@ Transformer::TransformationResult TrivialEdgePruner::transform(std::unique_ptr<C
     Logic & logic = graph->getLogic();
     // Test if any edge is satisfiable
     for (EId eid : directEdges) {
-        SMTConfig config;
-        MainSolver solver(graph->getLogic(), config, "");
+        SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::NONE);
+        auto & solver = solverWrapper.getCoreSolver();
         solver.insertFormula(graph->getEdgeLabel(eid));
         auto res = solver.check();
         if (res == s_True) {

--- a/src/utils/SmtSolver.cc
+++ b/src/utils/SmtSolver.cc
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "SmtSolver.h"
+
+SMTSolver::SMTSolver(Logic & logic, WitnessProduction setup) {
+    bool produceModel = setup == WitnessProduction::ONLY_MODEL || setup == WitnessProduction::MODEL_AND_INTERPOLANTS;
+    bool produceInterpolants =
+        setup == WitnessProduction::ONLY_INTERPOLANTS || setup == WitnessProduction::MODEL_AND_INTERPOLANTS;
+    const char * msg = "ok";
+    this->config.setOption(SMTConfig::o_produce_models, SMTOption(produceModel), msg);
+    this->config.setOption(SMTConfig::o_produce_inter, SMTOption(produceInterpolants), msg);
+    solver = std::make_unique<MainSolver>(logic, config, "");
+}
+
+void SMTSolver::resetSolver() {
+    solver = std::make_unique<MainSolver>(solver->getLogic(), config, "");
+}

--- a/src/utils/SmtSolver.h
+++ b/src/utils/SmtSolver.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef GOLEM_SMTSOLVER_H
+#define GOLEM_SMTSOLVER_H
+
+#include "include/osmt_solver.h"
+
+/**
+ * Simple wrapper around OpenSMT's MainSolver and SMTConfig
+ */
+class SMTSolver {
+    std::unique_ptr<MainSolver> solver;
+    SMTConfig config;
+
+public:
+    enum class WitnessProduction { NONE, ONLY_MODEL, ONLY_INTERPOLANTS, MODEL_AND_INTERPOLANTS };
+
+    // Default setup in OpenSMT is currently to produce models, but not interpolants
+    explicit SMTSolver(Logic & logic, WitnessProduction setup = WitnessProduction::ONLY_MODEL);
+
+    MainSolver & getCoreSolver() { return *solver; }
+
+    SMTConfig & getConfig() { return config; }
+
+    void resetSolver();
+};
+
+#endif // GOLEM_SMTSOLVER_H


### PR DESCRIPTION
The goal is to provide a simple abstraction over OpenSMT's solver so that we do not have to repeat unnecessary complicated setup of OpenSMT's SMTConfig and MainSolver. It would also better contain future changes in OpenSMT.

In the future, this abstraction can be extended to completly isolate OpenSMT's solver in a single place.