### PR TITLE
SimpleNodeEliminator: Allow restricted elimination of nodes with hyperedges

### DIFF
--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -343,8 +343,9 @@ DirectedHyperEdge ChcDirectedHyperGraph::mergeEdgePair(EId incoming, EId outgoin
     PTRef renamedLabel = utils.varSubstitute(getEdgeLabel(incoming), substitutionsMap);
 
     PTRef newLabel = logic.mkAnd(renamedLabel, getEdgeLabel(outgoing));
-    PTRef simplifiedLabel = TrivialQuantifierElimination(logic).tryEliminateVarsExcept(
-        utils.predicateArgsInOrder(getStateVersion(source)) + utils.predicateArgsInOrder(getNextStateVersion(target)), newLabel);
+    PTRef simplifiedLabel = TrivialQuantifierElimination(logic).tryEliminateVars(
+        utils.predicateArgsInOrder(getStateVersion(common)), newLabel
+    );
 
     for (auto & v : sources) {
         if (v == common) { v = source; }

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -305,6 +305,7 @@ private:
         }
     }
 
+    DirectedHyperEdge mergeEdgePair(EId first, EId second);
     DirectedHyperEdge mergeEdges(std::vector<EId> const & chain);
     PTRef mergeLabels(std::vector<EId> const & chain);
 };

--- a/src/transformers/CommonUtils.cc
+++ b/src/transformers/CommonUtils.cc
@@ -148,7 +148,6 @@ InvalidityWitness::Derivation expandStepWithHyperEdge(
     TermUtils::substitutions_map subst;
     TermUtils utils(logic);
     auto const & replacingEdge = contractionInfo.first;
-    assert(replacingEdge.from.size() == 1);
     assert(summarizedStep.premises.size() == replacingEdge.from.size());
     assert(logic.getSymRef(summarizedStep.derivedFact) == replacingEdge.to);
 

--- a/src/transformers/CommonUtils.cc
+++ b/src/transformers/CommonUtils.cc
@@ -108,3 +108,128 @@ InvalidityWitness::Derivation replaceSummarizingStep(
     InvalidityWitness::Derivation newDerivation(std::move(newSteps));
     return newDerivation;
 }
+
+
+
+InvalidityWitness::Derivation expandStepWithHyperEdge(
+    InvalidityWitness::Derivation const & derivation,
+    std::size_t stepIndex,
+    ContractionInfo const & contractionInfo,
+    NonlinearCanonicalPredicateRepresentation const & predicateRepresentation,
+    Logic & logic
+    ) {
+    assert(stepIndex < derivation.size());
+    // Replace this step with the sequence of steps corresponding to the summarized chain
+    std::vector<DerivationStep> newSteps;
+    newSteps.reserve(stepIndex);
+    // 1. Copy all the steps before the one to be replaced
+    std::copy(derivation.begin(), derivation.begin() + stepIndex, std::back_inserter(newSteps));
+    std::size_t firstShiftedIndex = newSteps.size();
+    // 2. Replace the summarized step
+    DerivationStep const & summarizedStep = derivation[stepIndex];
+    // 2a. Compute instance for the contracted node
+    // 2aa. Compute path constraint
+    auto const & incoming = contractionInfo.second.first;
+    auto const & outgoing = contractionInfo.second.second;
+    auto contractedNode = incoming.to;
+    assert(std::count(outgoing.from.begin(), outgoing.from.end(), contractedNode) == 1); // It has to be there, and currently not more than once
+    assert(incoming.from.size() == 1);
+    bool sourceIsEntry = incoming.from.at(0) == logic.getSym_true();
+    PTRef constraint = logic.mkAnd(incoming.fla.fla, outgoing.fla.fla);
+    auto unifiedConstraint = [&](PTRef constraint) -> PTRef {
+        vec<PTRef> unifyingEqualities;
+        PTRef sourceTerm = predicateRepresentation.getSourceTermFor(contractedNode, 0);
+        PTRef targetTerm = predicateRepresentation.getTargetTermFor(contractedNode);
+        TermUtils::substitutions_map substitutionsMap;
+        TermUtils(logic).mapFromPredicate(sourceTerm, targetTerm, substitutionsMap);
+        return TermUtils(logic).varSubstitute(constraint, substitutionsMap);
+    }(constraint);
+    // 2ab Compute constraints for the other nodes
+    TermUtils::substitutions_map subst;
+    TermUtils utils(logic);
+    auto const & replacingEdge = contractionInfo.first;
+    assert(replacingEdge.from.size() == 1);
+    assert(summarizedStep.premises.size() == replacingEdge.from.size());
+    assert(logic.getSymRef(summarizedStep.derivedFact) == replacingEdge.to);
+
+    const PTRef targetPredicate = predicateRepresentation.getTargetTermFor(replacingEdge.to);
+    utils.mapFromPredicate(targetPredicate, summarizedStep.derivedFact, subst);
+    {
+        // TODO: Better way to compute instances correctly?
+        std::unordered_map<SymRef, std::size_t, SymRefHash> instanceCounter;
+        for (auto i = 0u; i < summarizedStep.premises.size(); ++i) {
+            PTRef derivedFact = derivation[summarizedStep.premises[i]].derivedFact;
+            if (logic.getSymRef(derivedFact) != replacingEdge.from[i]) {
+                throw std::logic_error("Order of nodes does not match!");
+            }
+            PTRef sourcePredicate = predicateRepresentation.getSourceTermFor(replacingEdge.from[i],
+                                                                             instanceCounter[replacingEdge.from[i]]++);
+            utils.mapFromPredicate(sourcePredicate, derivedFact, subst);
+        }
+    }
+
+    SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+    auto & solver = solverWrapper.getCoreSolver();
+    solver.insertFormula(unifiedConstraint);
+    for (auto const & [var,value] : subst) {
+        assert(logic.isVar(var) and logic.isConstant(value));
+        solver.insertFormula(logic.mkEq(var, value));
+    }
+    // 2ac Compute values for summarized predicates from model
+    auto res = solver.check();
+    if (res != s_True) { throw std::logic_error("Proof transformation: Summarized edges should have been satisfiable!"); }
+    auto model = solver.getModel();
+    PTRef targetTerm = predicateRepresentation.getTargetTermFor(contractedNode);
+    auto vars = utils.predicateArgsInOrder(targetTerm);
+    subst.clear();
+    for (PTRef var : vars) {
+        subst.insert({var, model->evaluate(var)});
+    }
+    PTRef contractedNodeInstance = utils.varSubstitute(targetTerm, subst);
+    // 2b. Create new steps based on intermediate predicate instance
+    assert(not newSteps.empty());
+    DerivationStep intermediateStep;
+    intermediateStep.derivedFact = contractedNodeInstance;
+    intermediateStep.index = newSteps.size();
+    auto originalSourcePremiseIndex = [&]() -> std::size_t {
+        for (auto i = 0u; i < outgoing.from.size(); ++i) {
+            if (outgoing.from[i] == contractedNode) {
+                // If the source of incoming is entry node, it will not be included in the premises after contraction!
+                return sourceIsEntry ? 0u : summarizedStep.premises[i];
+            }
+        }
+        assert(false);
+        throw std::logic_error("UnReachable");
+    }();
+    intermediateStep.premises = {originalSourcePremiseIndex};
+    intermediateStep.clauseId = incoming.id;
+    newSteps.push_back(std::move(intermediateStep));
+    std::size_t diff = 1;
+    // 2c. fix the step deriving the target of the summarized chain
+    DerivationStep step = summarizedStep;
+    if (sourceIsEntry) {
+        auto it = std::find(outgoing.from.begin(), outgoing.from.end(), contractedNode);
+        assert(it != outgoing.from.end());
+        auto position = it - outgoing.from.begin();
+        step.premises.insert(step.premises.begin() + position, newSteps.size() - 1);
+    } else {
+        std::replace(step.premises.begin(), step.premises.end(), originalSourcePremiseIndex, newSteps.size() - 1);
+    }
+    step.index += diff;
+    step.clauseId = outgoing.id;
+    newSteps.push_back(std::move(step));
+    // 3. copy all steps after the one replaced and update their premise indices
+    std::transform(derivation.begin() + stepIndex + 1, derivation.end(), std::back_inserter(newSteps), [diff, firstShiftedIndex](auto const & step){
+        auto newStep = step;
+        for (auto & premiseIndex : newStep.premises) {
+            if (premiseIndex >= firstShiftedIndex) {
+                premiseIndex += diff;
+            }
+        }
+        newStep.index += diff;
+        return newStep;
+    });
+    // 4. Return the derivation
+    InvalidityWitness::Derivation newDerivation(std::move(newSteps));
+    return newDerivation;
+}

--- a/src/transformers/CommonUtils.h
+++ b/src/transformers/CommonUtils.h
@@ -75,4 +75,14 @@ InvalidityWitness::Derivation replaceSummarizingStep(
     Logic & logic
     );
 
+using ContractionInfo = std::pair<DirectedHyperEdge, std::pair<DirectedHyperEdge, DirectedHyperEdge>>;
+
+InvalidityWitness::Derivation expandStepWithHyperEdge(
+    InvalidityWitness::Derivation const & derivation,
+    std::size_t stepIndex,
+    ContractionInfo const & contractionInfo,
+    NonlinearCanonicalPredicateRepresentation const & predicateRepresentation,
+    Logic & logic
+);
+
 #endif //GOLEM_COMMONUTILS_H

--- a/src/transformers/NodeEliminator.cc
+++ b/src/transformers/NodeEliminator.cc
@@ -59,7 +59,7 @@ bool SimpleNodeEliminatorPredicate::operator()(
         auto const & outgoing = ar.getOutgoingEdgesFor(vertex);
         return std::all_of(outgoing.begin(), outgoing.end(), [&](EId edge) {
             auto const & sources = graph.getSources(edge);
-           return std::count(sources.begin(), sources.end(), vertex) == 1;
+           return vertex != graph.getTarget(edge) and std::count(sources.begin(), sources.end(), vertex) == 1;
         });
     }
     return false;

--- a/src/transformers/NodeEliminator.cc
+++ b/src/transformers/NodeEliminator.cc
@@ -7,6 +7,7 @@
 #include "NodeEliminator.h"
 
 #include "CommonUtils.h"
+#include "utils/SmtSolver.h"
 
 void NodeEliminator::BackTranslator::notifyRemovedVertex(SymRef sym, ContractionResult && contractionResult) {
     assert(nodeInfo.count(sym) == 0);
@@ -47,8 +48,21 @@ bool SimpleNodeEliminatorPredicate::operator()(
     SymRef vertex,
     AdjacencyListsGraphRepresentation const & ar,
     ChcDirectedHyperGraph const & graph) const {
-    // TODO: Remove the constraint about hyperEdge
-    return not hasHyperEdge(vertex, ar, graph) and isSimpleNode(vertex, ar) and isNonLoopNode(vertex, ar, graph);
+    if (isSimpleNode(vertex, ar) and isNonLoopNode(vertex, ar, graph)) {
+        if (not hasHyperEdge(vertex, ar, graph)) { return true; }
+        // We eliminate the node also if it has outgoing hyperedges,
+        // under the condition that it has only a single incoming edge, which is simple,
+        // and it occurs only once as a source in each outgoing hyperedge
+        // TODO: Relax also this constraint
+        auto const & incoming = ar.getIncomingEdgesFor(vertex);
+        if (not (incoming.size() == 1 and graph.getSources(incoming[0]).size() == 1)) { return false; }
+        auto const & outgoing = ar.getOutgoingEdgesFor(vertex);
+        return std::all_of(outgoing.begin(), outgoing.end(), [&](EId edge) {
+            auto const & sources = graph.getSources(edge);
+           return std::count(sources.begin(), sources.end(), vertex) == 1;
+        });
+    }
+    return false;
 }
 InvalidityWitness NodeEliminator::BackTranslator::translate(InvalidityWitness witness) {
     if (this->removedNodes.empty()) { return witness; }
@@ -75,11 +89,23 @@ InvalidityWitness NodeEliminator::BackTranslator::translate(InvalidityWitness wi
             auto eid = it->clauseId;
             if (auto possibleContractInfo = findContractionInfo(eid); possibleContractInfo.has_value()) {
                 auto const & contractionInfo = possibleContractInfo.value();
-                std::vector<DirectedHyperEdge> chain = {contractionInfo.second.first, contractionInfo.second.second};
-                auto const & replacingEdge = contractionInfo.first;
-                std::size_t index = it - derivation.begin();
-                auto newDerivation = replaceSummarizingStep(derivation, index, chain, replacingEdge, predicateRepresentation, logic);
-                witness.setDerivation(std::move(newDerivation));
+                // Incoming edge cannot be a hyperedge, but outgoing can!
+                assert(contractionInfo.second.first.from.size() == 1);
+                // TODO: Unify handling of hyperedges with summarized chains
+                if (contractionInfo.second.second.from.size() == 1) {
+                    std::vector<DirectedHyperEdge> chain = {contractionInfo.second.first,
+                                                            contractionInfo.second.second};
+                    auto const & replacingEdge = contractionInfo.first;
+                    std::size_t index = it - derivation.begin();
+                    auto newDerivation =
+                        replaceSummarizingStep(derivation, index, chain, replacingEdge, predicateRepresentation, logic);
+                    witness.setDerivation(std::move(newDerivation));
+                } else { // outgoing is a hyperedge
+                    std::size_t index = it - derivation.begin();
+                    auto newDerivation =
+                        expandStepWithHyperEdge(derivation, index, contractionInfo, predicateRepresentation, logic);
+                    witness.setDerivation(std::move(newDerivation));
+                }
                 stepReplaced = true;
                 break;
             }
@@ -91,6 +117,7 @@ InvalidityWitness NodeEliminator::BackTranslator::translate(InvalidityWitness wi
     return witness;
 }
 
+#define SANITY_CHECK(cond) if (not (cond)) { assert(false); return ValidityWitness{}; }
 ValidityWitness NodeEliminator::BackTranslator::translate(ValidityWitness witness) {
     if (this->removedNodes.empty()) { return witness; }
     auto definitions = witness.getDefinitions();
@@ -113,39 +140,46 @@ ValidityWitness NodeEliminator::BackTranslator::translate(ValidityWitness witnes
         for (auto const & edge : info.incoming) {
             if (edge.from.size() != 1) { throw std::logic_error("NonLoopEliminator should not have processed hyperEdges!"); }
             PTRef sourceDef = definitionFor(edge.from[0]);
-            assert(sourceDef != PTRef_Undef);
-            if (sourceDef == PTRef_Undef) { // Missing definition, cannot backtranslate
-                return ValidityWitness{};
-            }
+            SANITY_CHECK(sourceDef != PTRef_Undef); // Missing definition, cannot backtranslate
             sourceDef = manager.baseFormulaToSource(sourceDef);
             incomingFormulas.push(logic.mkAnd(sourceDef, edge.fla.fla));
         }
         vec<PTRef> outgoingFormulas;
         for (auto const & edge : info.outgoing) {
-            if (edge.from.size() != 1) { throw std::logic_error("NonLoopEliminator should not have processed hyperEdges!"); }
+            vec<PTRef> components;
+            components.push(edge.fla.fla);
             PTRef targetDef = definitionFor(edge.to);
-            assert(targetDef != PTRef_Undef);
-            if (targetDef == PTRef_Undef) { // Missing definition, cannot backtranslate
-                return ValidityWitness{};
-            }
+            SANITY_CHECK(targetDef != PTRef_Undef); // Missing definition, cannot backtranslate
             targetDef = manager.baseFormulaToTarget(targetDef);
-            outgoingFormulas.push(logic.mkAnd(edge.fla.fla, logic.mkNot(targetDef)));
+            components.push(logic.mkNot(targetDef));
+            if (edge.from.size() > 1) { // HyperEdge
+                auto sources = edge.from;
+                auto vertexOccurences = std::count(sources.begin(), sources.end(), vertex);
+                SANITY_CHECK(vertexOccurences == 1);
+                sources.erase(std::remove(sources.begin(), sources.end(), vertex), sources.end());
+                std::unordered_map<SymRef, std::size_t, SymRefHash> instances;
+                for (auto otherSource : sources) {
+                    auto instance = instances[otherSource]++;
+                    PTRef sourceDef = definitionFor(otherSource);
+                    SANITY_CHECK(sourceDef != PTRef_Undef); // Missing definition, cannot backtranslate
+                    sourceDef = manager.baseFormulaToSource(sourceDef, instance);
+                    components.push(sourceDef);
+                }
+            }
+            outgoingFormulas.push(logic.mkAnd(std::move(components)));
         }
         TermUtils::substitutions_map substitutionsMap;
         utils.mapFromPredicate(predicateRepresentation.getSourceTermFor(vertex), predicateRepresentation.getTargetTermFor(vertex), substitutionsMap);
         PTRef incomingPart = logic.mkOr(std::move(incomingFormulas));
         PTRef outgoingPart = logic.mkOr(std::move(outgoingFormulas));
         outgoingPart = utils.varSubstitute(outgoingPart, substitutionsMap);
-        SMTConfig config;
-        const char * msg;
-        config.setOption(SMTConfig::o_produce_models, SMTOption(false), msg);
-        config.setOption(SMTConfig::o_produce_inter, SMTOption(true), msg);
-        MainSolver solver(logic, config, "solver");
+        SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+        auto & solver = solverWrapper.getCoreSolver();
         solver.insertFormula(incomingPart);
         solver.insertFormula(outgoingPart);
         auto res = solver.check();
         if (res != s_False) {
-            throw std::logic_error("Error in backtranslating of nonloops elimination");
+            throw std::logic_error("Error in backtranslating of nonloop elimination");
         }
         auto itpContext = solver.getInterpolationContext();
         vec<PTRef> itps;


### PR DESCRIPTION
This change extends SimpleNodeEliminator so it also eliminates nodes with single incoming simple edge and any number of outgoing (hyper)edges.
Previously, a node was not eliminated if it participated in a hyperedge.
  
The proposed change leads to more nodes eliminated in some benchmarks of CHC-COMP, which helps the Spacer engine on nonlinear systems.
Additionally, some nonlinear systems can be translated to linear ones by this transformation, enabling other engines to solve some nonlinear benchmarks.
