### PR TITLE
DAG-disj: Fixed conjunction to disjunction in "addRestrictions"

### DIFF
--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -1521,12 +1521,12 @@ private:
 };
 
 void TransitionSystemNetworkManager::addRestrictions(SymRef node, PTRef fla) {
-    getNode(node).accumulatedRestrictions = logic.mkAnd(fla, getNode(node).accumulatedRestrictions);
+    getNode(node).accumulatedRestrictions = logic.mkOr(fla, getNode(node).accumulatedRestrictions);
 }
 
 void TransitionSystemNetworkManager::updateRestrictions(SymRef node) {
     getNode(node).solver->updateQueryStates(getNode(node).accumulatedRestrictions);
-    getNode(node).accumulatedRestrictions = logic.getTerm_true();
+    getNode(node).accumulatedRestrictions = logic.getTerm_false();
 }
 
 VerificationResult TPAEngine::solveTransitionSystemGraph(const ChcDirectedGraph & graph) {


### PR DESCRIPTION
## Bug Fix
### Description:
The conjunction of constraints(which was used previously), restricted the paths which should not've been restricted, leading to the spurious SAFE results.

### Solution:
- Conjunction was replaced with disjunction, therefore as long as at least one branch is reachable from the end of TS, we still should consider the node as a potential candidate.
- Two tests are added to validate this specific property.