### PR TITLE
Fix incorrect behaviour detected on a test case

### DIFF
--- a/test/test_MBP.cc
+++ b/test/test_MBP.cc
@@ -546,3 +546,18 @@ TEST_F(MBP_IntTest, test_ResolvesToTrue) {
     EXPECT_EQ(res, logic.mkEq(zero, logic.mkMod(logic.mkMinus(x, one), five)));
 }
 
+TEST_F(MBP_IntTest, test_ExtendedModelForDivisibilityInThePresenceOfDisequality) {
+    PTRef ten = logic.mkIntConst(10);
+    PTRef neq = logic.mkNot(logic.mkEq(x, one));
+    PTRef lb = logic.mkLeq(one, y);
+    PTRef lb2 = logic.mkLeq(z, y);
+    PTRef ub = logic.mkLeq(y, ten);
+    PTRef withMod = logic.mkEq(logic.mkMod(logic.mkMinus(logic.mkPlus(vec<PTRef>{x, y, z}), one), ten), zero);
+    PTRef fla = logic.mkAnd({neq, lb, lb2, ub, withMod});
+    auto model = getModel({{x, zero}, {y, one}, {z, logic.mkIntConst(-10)}});
+    PTRef res = mbp.project(fla, {x, y, z}, *model);
+    std::cout << logic.pp(res) << std::endl;
+    // Just check that it went through. Originally, this was crashing on assertion violation in MBP.
+    ASSERT_EQ(res, logic.getTerm_true());
+}
+


### PR DESCRIPTION
This PR introduces fixes for two problems.
One is a corner case in model-based projection where a presence of ~false literal would cause incorrect computation of extended model when handling divisibility constraints.

After this fix, proof production on the same example showed that after the recent changes in the normalization process we no longer version auxiliary variables introduced during elimination of ITE/DIV/MOD operators.
The proposed change here is to version those variables immediately after their creation.