### PR TITLE
Graph: More carefule node elimination

### DIFF
--- a/src/TermUtils.h
+++ b/src/TermUtils.h
@@ -260,6 +260,15 @@ public:
         return logic.mkVar(sort, varName.c_str());
     }
 
+    std::string getUnversionedName(PTRef var) {
+        assert(logic.isVar(var));
+        assert(isVersioned(var));
+        std::string varName = logic.getSymName(var);
+        auto pos = varName.rfind(versionSeparator);
+        varName.erase(pos);
+        return varName;
+    }
+
     int getVersionNumber(PTRef var) {
         assert(logic.isVar(var));
         assert(isVersioned(var));

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -312,7 +312,7 @@ private:
         }
     }
 
-    DirectedHyperEdge mergeEdgePair(EId first, EId second);
+    DirectedHyperEdge mergeEdgePair(EId first, EId second, bool requiresRenamingAuxiliaryVars = false);
     DirectedHyperEdge mergeEdges(std::vector<EId> const & chain);
     PTRef mergeLabels(std::vector<EId> const & chain);
 };


### PR DESCRIPTION
When contracting a vertex with an incoming edge that has auxiliary
variables, we have to be careful not to end up with the same auxiliary
variable in the labels of multiple edges. This could cause problems when
considering paths containing such edges, because we could end up with a
name clash.
    
The current fix is to rename auxiliary variables when this potential
clash could occur.
    
In the future we should rethink our versioning strategy, possibly
enforce stronger invariants that would prevent this scenario in the
first place.

Fixes #51.
