### PR TITLE
Performance optimizations and small cleanup in Alethe proof production

### DIFF
--- a/src/Witnesses.cc
+++ b/src/Witnesses.cc
@@ -29,8 +29,8 @@ void VerificationResult::printWitness(std::ostream & out, Logic & logic, const C
                                         normalizingEqualities,
                                         logic, originalGraph);
                 if (format == "alethe") {
-                    AlethePrintObserver alethePrintObserver(out);
-                    stepHandler.registerObserver(&alethePrintObserver);
+                    AlethePrintObserver observer(out);
+                    stepHandler.registerObserver(&observer);
                     stepHandler.buildAletheProof();
                 } else if (format == "intermediate") {
                     IntermediatePrintObserver intermediatePrintObserver(out);

--- a/src/proofs/ProofSteps.cc
+++ b/src/proofs/ProofSteps.cc
@@ -222,11 +222,11 @@ void StepHandler::buildAletheProof() {
 
         // Casting implication to an operation, getting the LHS and calling the simplification visitor
         std::dynamic_pointer_cast<Op>(currTerm)->getArgs()[0]->accept(&congChainVisitor);
-
         // If it is empty, it means that the LHS was either a terminal or an application
-        if (not congChainVisitor.getSteps().empty()) {
-            for (std::size_t j = 0; j < congChainVisitor.getSteps().size() - 1; j++) {
-                auto simpleStep = congChainVisitor.getSteps()[j];
+        auto const & congruenceChainSteps = congChainVisitor.getSteps();
+        if (not congruenceChainSteps.empty()) {
+            for (std::size_t j = 0; j < congruenceChainSteps.size() - 1; j++) {
+                auto const & simpleStep = congruenceChainSteps[j];
                 notifyObservers(Step(simpleStep.stepId, Step::STEP, packClause(simpleStep.clause), simpleStep.rule,
                                      simpleStep.premises));
             }
@@ -236,7 +236,8 @@ void StepHandler::buildAletheProof() {
         // Checking if we are dealing with a conjunction
         if (implicationLHS->getTermType() == Term::OP) {
             // renaming LHS for last chain step
-            auto lastChainStep = congChainVisitor.getSteps()[congChainVisitor.getSteps().size() - 1];
+            assert(not congruenceChainSteps.empty());
+            auto const & lastChainStep = congruenceChainSteps.back();
             lastClause = lastChainStep.clause;
             notifyObservers(
                 Step(lastChainStep.stepId, Step::STEP,

--- a/src/proofs/ProofSteps.h
+++ b/src/proofs/ProofSteps.h
@@ -55,6 +55,15 @@ public:
     void update(Step const & step) override { out << step.printStepAlethe(); }
 };
 
+class [[maybe_unused]] CountingObserver : public Observer {
+    std::size_t count = 0;
+
+public:
+    CountingObserver() = default;
+    ~CountingObserver() { std::cout << count << std::endl; }
+    void update(Step const &) override { ++count; }
+};
+
 class IntermediatePrintObserver : public Observer {
     std::ostream & out;
 

--- a/src/proofs/ProofSteps.h
+++ b/src/proofs/ProofSteps.h
@@ -82,7 +82,6 @@ class StepHandler {
     std::vector<std::size_t> modusPonensSteps; // Modus Ponens Steps to derive the next node
 
     // Visitors
-    InstantiateVisitor copyVisitor;
     OperateLetTermVisitor operateLetTermVisitor;
     LetLocatorVisitor letLocatorVisitor;
     RemoveUnusedVisitor removeUnusedVisitor;

--- a/src/proofs/Term.cc
+++ b/src/proofs/Term.cc
@@ -97,10 +97,9 @@ std::shared_ptr<Term> CongChainVisitor::visit(Terminal * term) {
 std::shared_ptr<Term> CongChainVisitor::visit(Op * term) {
 
     transCase = 0;
-    auto args = term->getArgs();
     bool canSimplify = true;
 
-    for (auto const & arg : args) {
+    for (auto const & arg : term->getArgs()) {
         if (not(arg->getTermType() == Term::TERMINAL or arg->getTermType() == Term::APP)) {
             canSimplify = false;
             break;

--- a/src/proofs/Term.cc
+++ b/src/proofs/Term.cc
@@ -125,7 +125,8 @@ std::shared_ptr<Term> CongChainVisitor::visit(Op * term) {
                                std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{lessOrEq, innerWorking}),
                                premises, std::dynamic_pointer_cast<Op>(lessOrEq)->simplifyRule());
             currentStep++;
-            auto innerSimplified = std::make_shared<Op>(simplificationOp->getOp(), std::vector<std::shared_ptr<Term>>{innerWorking});
+            auto innerSimplified =
+                std::make_shared<Op>(simplificationOp->getOp(), std::vector<std::shared_ptr<Term>>{innerWorking});
             auto cong = std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{simplification, innerSimplified});
 
             steps.emplace_back(currentStep, cong, std::vector<std::size_t>{currentStep - 1}, "cong");
@@ -137,12 +138,10 @@ std::shared_ptr<Term> CongChainVisitor::visit(Op * term) {
                 innerSimplified->simplifyRule());
 
             currentStep++;
-            auto trans =
-                std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{simplification, outerWorking});
+            auto trans = std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{simplification, outerWorking});
             steps.emplace_back(currentStep, trans, std::vector<std::size_t>{currentStep - 2, currentStep - 1}, "trans");
             currentStep++;
-            trans =
-                std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), outerWorking});
+            trans = std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), outerWorking});
             steps.emplace_back(currentStep, trans, std::vector<std::size_t>{currentStep - 5, currentStep - 1}, "trans");
             currentStep++;
             return outerWorking;
@@ -150,12 +149,10 @@ std::shared_ptr<Term> CongChainVisitor::visit(Op * term) {
             transCase = 1;
             auto simplified = std::dynamic_pointer_cast<Op>(simplification)->operate();
             steps.emplace_back(
-                currentStep,
-                std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{simplification, simplified}),
+                currentStep, std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{simplification, simplified}),
                 premises, std::dynamic_pointer_cast<Op>(simplification)->simplifyRule());
             currentStep++;
-            auto trans = std::make_shared<Op>(
-                "=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), simplified});
+            auto trans = std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), simplified});
             steps.emplace_back(currentStep, trans, std::vector<std::size_t>{currentStep - 2, currentStep - 1}, "trans");
             currentStep++;
             return simplified;
@@ -173,8 +170,8 @@ std::shared_ptr<Term> CongChainVisitor::visit(Op * term) {
         steps.emplace_back(currentStep, cong, premises, "cong");
         currentStep++;
         auto furtherSimplification = modifiedTerm->accept(this);
-        auto trans = std::make_shared<Op>(
-            "=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), furtherSimplification});
+        auto trans =
+            std::make_shared<Op>("=", std::vector<std::shared_ptr<Term>>{term->asSharedPtr(), furtherSimplification});
         std::size_t predecessor;
         if (transCase == 1) {
             predecessor = currentStep - 4;

--- a/src/proofs/Term.cc
+++ b/src/proofs/Term.cc
@@ -362,7 +362,6 @@ std::shared_ptr<Term> SimplifyVisitor::visit(Let * term) {
 
 std::shared_ptr<Term> Op::operate() const {
     std::vector<std::shared_ptr<Term>> newArgs;
-    InstantiateVisitor copyVisitor;
     std::string firstStr;
     std::string secondStr;
     FastRational firstTerm;

--- a/src/proofs/Term.cc
+++ b/src/proofs/Term.cc
@@ -10,7 +10,7 @@
 #include <memory>
 #include <string>
 
-bool Op::nonLinearity() {
+bool Op::nonLinearity() const {
     if (operation == "and") {
         auto predicates = std::count_if(args.begin(), args.end(), [](auto const & arg) {
             return arg->getTermType() == Term::APP or arg->getTerminalType() == Terminal::VAR;
@@ -20,7 +20,7 @@ bool Op::nonLinearity() {
     return false;
 }
 
-std::string Op::nonLinearSimplification() {
+std::string Op::nonLinearSimplification() const {
     std::stringstream ss;
     if (operation == "and") {
         for (std::size_t i = 0; i < args.size(); i++) {
@@ -192,7 +192,7 @@ std::shared_ptr<Term> CongChainVisitor::visit(App * term) {
     return std::make_shared<App>(term->getFun(), term->getArgs());
 }
 
-std::string Op::simplifyRule() {
+std::string Op::simplifyRule() const {
     std::string op = operation;
     if (op == "=") {
         if ((args[0]->printTerm().find_first_not_of("( )-0123456789") == std::string::npos) and

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -14,8 +14,8 @@ class Term : public std::enable_shared_from_this<Term> {
 public:
     enum termType { APP, OP, TERMINAL, QUANT, LET };
     enum terminalType { VAR, REAL, INT, SORT, BOOL, UNDECLARED };
-    virtual termType getTermType() = 0;
-    virtual terminalType getTerminalType() = 0;
+    virtual termType getTermType() const  = 0;
+    virtual terminalType getTerminalType() const = 0;
     virtual void accept(class VoidVisitor *) = 0;
     virtual std::shared_ptr<Term> accept(class LogicVisitor *) = 0;
     virtual Term * accept(class PointerVisitor *) = 0;
@@ -32,8 +32,8 @@ public:
     Terminal(std::string val, terminalType t) : val(std::move(val)), type(t) {}
     std::string const & getVal() { return val; }
     terminalType const & getType() { return type; }
-    termType getTermType() override { return TERMINAL; }
-    terminalType getTerminalType() override { return type; }
+    termType getTermType() const override { return TERMINAL; }
+    terminalType getTerminalType() const override { return type; }
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;
     Term * accept(PointerVisitor *) override;
@@ -47,13 +47,13 @@ class Op : public Term {
 public:
     Op(std::string opcode, std::vector<std::shared_ptr<Term>> args)
         : operation(std::move(opcode)), args(std::move(args)) {}
-    std::string const & getOp() { return operation; }
-    std::vector<std::shared_ptr<Term>> const & getArgs() { return args; }
-    termType getTermType() override { return OP; }
-    terminalType getTerminalType() override { return UNDECLARED; }
-    std::string simplifyRule();
-    bool nonLinearity();
-    std::string nonLinearSimplification();
+    std::string const & getOp() const { return operation; }
+    std::vector<std::shared_ptr<Term>> const & getArgs() const { return args; }
+    termType getTermType() const override { return OP; }
+    terminalType getTerminalType() const override { return UNDECLARED; }
+    std::string simplifyRule() const;
+    bool nonLinearity() const;
+    std::string nonLinearSimplification() const;
     void setArg(int i, std::shared_ptr<Term> newArg) { args[i] = std::move(newArg); }
     std::shared_ptr<Term> operate() const;
 
@@ -70,8 +70,8 @@ public:
     App(std::string fun, std::vector<std::shared_ptr<Term>> args) : fun(std::move(fun)), args(std::move(args)) {}
     std::string const & getFun() { return fun; }
     std::vector<std::shared_ptr<Term>> const & getArgs() { return args; }
-    termType getTermType() override { return APP; }
-    terminalType getTerminalType() override { return UNDECLARED; }
+    termType getTermType() const override { return APP; }
+    terminalType getTerminalType() const override { return UNDECLARED; }
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;
     Term * accept(PointerVisitor *) override;
@@ -92,8 +92,8 @@ public:
     std::vector<std::shared_ptr<Term>> const & getVars() { return vars; }
     std::vector<std::shared_ptr<Term>> const & getSorts() { return sorts; }
     std::shared_ptr<Term> getCoreTerm() { return coreTerm; }
-    termType getTermType() override { return QUANT; }
-    terminalType getTerminalType() override { return UNDECLARED; }
+    termType getTermType() const override { return QUANT; }
+    terminalType getTerminalType() const override { return UNDECLARED; }
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;
     Term * accept(PointerVisitor *) override;
@@ -112,8 +112,8 @@ public:
     std::vector<std::shared_ptr<Term>> const & getDeclarations() { return declarations; }
     std::shared_ptr<Term> const & getApplication() { return application; }
     std::vector<std::string> const & getTermNames() { return termNames; }
-    termType getTermType() override { return LET; }
-    terminalType getTerminalType() override { return UNDECLARED; }
+    termType getTermType() const override { return LET; }
+    terminalType getTerminalType() const override { return UNDECLARED; }
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;
     Term * accept(PointerVisitor *) override;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -228,7 +228,7 @@ public:
     std::shared_ptr<Term> visit(App *) override;
     std::shared_ptr<Term> visit(Let *) override { throw std::logic_error("This should not have happened!"); };
 
-    std::vector<SimpleStep> getSteps() { return steps; };
+    std::vector<SimpleStep> const & getSteps() { return steps; };
 };
 
 class PointerVisitor {

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -6,9 +6,13 @@
 
 #ifndef GOLEM_TERM_H
 #define GOLEM_TERM_H
-#include "utils/SmtSolver.h"
+
 #include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 class Term : public std::enable_shared_from_this<Term> {
 public:
@@ -183,8 +187,6 @@ public:
 };
 
 class VoidVisitor {
-    std::stringstream ss;
-
 public:
     virtual void visit(Terminal *) = 0;
     virtual void visit(Quant *) = 0;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -146,7 +146,7 @@ public:
 };
 
 class RemoveUnusedVisitor : public LogicVisitor {
-    std::vector<std::string> varsInUse;
+    std::unordered_set<std::string> varsInUse;
 
 public:
     std::shared_ptr<Term> visit(Terminal *) override;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <utility>
 
-class Term {
+class Term : public std::enable_shared_from_this<Term> {
 public:
     enum termType { APP, OP, TERMINAL, QUANT, LET };
     enum terminalType { VAR, REAL, INT, SORT, BOOL, UNDECLARED };
@@ -20,6 +20,7 @@ public:
     virtual std::shared_ptr<Term> accept(class LogicVisitor *) = 0;
     virtual Term * accept(class PointerVisitor *) = 0;
     virtual std::string printTerm();
+    std::shared_ptr<Term> asSharedPtr() { return shared_from_this(); }
     virtual ~Term() = default;
 };
 

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -18,7 +18,7 @@ class Term : public std::enable_shared_from_this<Term> {
 public:
     enum termType { APP, OP, TERMINAL, QUANT, LET };
     enum terminalType { VAR, REAL, INT, SORT, BOOL, UNDECLARED };
-    virtual termType getTermType() const  = 0;
+    virtual termType getTermType() const = 0;
     virtual terminalType getTerminalType() const = 0;
     virtual void accept(class VoidVisitor *) = 0;
     virtual std::shared_ptr<Term> accept(class LogicVisitor *) = 0;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -55,7 +55,7 @@ public:
     bool nonLinearity();
     std::string nonLinearSimplification();
     void setArg(int i, std::shared_ptr<Term> newArg) { args[i] = std::move(newArg); }
-    std::shared_ptr<Term> operate();
+    std::shared_ptr<Term> operate() const;
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;
     Term * accept(PointerVisitor *) override;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -54,7 +54,6 @@ public:
     std::string simplifyRule() const;
     bool nonLinearity() const;
     std::string nonLinearSimplification() const;
-    void setArg(int i, std::shared_ptr<Term> newArg) { args[i] = std::move(newArg); }
     std::shared_ptr<Term> operate() const;
 
     std::shared_ptr<Term> accept(LogicVisitor *) override;

--- a/src/proofs/Term.h
+++ b/src/proofs/Term.h
@@ -207,7 +207,6 @@ public:
 
 class CongChainVisitor : public LogicVisitor {
     int transCase = 0; // 0 for regular case, 1 for trans after ">="
-    InstantiateVisitor copyVisitor;
     std::size_t currentStep;
     class SimpleStep {
     public:


### PR DESCRIPTION
Investigation into a performance issues on some CHC-COMP benchmarks revealed that every access to the steps computed by the `CongChainVisitor` created a new copy of the steps, which was a performance killer, since this actually happened on access to each step. The easy fix here is to return (and use) just a reference to the stored vector of steps.

Additionally we make use of a C++ [`std::enable_shared_from_this`](https://en.cppreference.com/w/cpp/memory/enable_shared_from_this) that allow us to still use the visitor pattern, but turn the raw pointer back to shared pointers without the risk of creating two separate `shared_ptr` managing the same raw pointer. Since we only create `Term`s as shared pointers, this is safe, but we should make another step and hide all constructors and only expose a factory method returning `shared_ptr`.