### PR TITLE
Alethe: Fix evaluation of modulo operation

### DIFF
--- a/test/prooftesting/negative_mod.smt2
+++ b/test/prooftesting/negative_mod.smt2
@@ -1,0 +1,11 @@
+(set-logic HORN)
+(declare-fun Q (Int) Bool)
+(assert (forall ((x Int)) (=> (and (< x 0) (= (mod x 3) 1)) (Q x))
+))
+
+
+(assert (forall ((x Int))
+    (=> (Q x) false)
+))
+
+(check-sat)


### PR DESCRIPTION
The semantics of the modulo operation on OpenSMT's FastRationals is different than the semantics of modulo as defined by SMT-LIB. This commit changes the evaluation of a modulo operation on two integers to follow the SMT-LIB semantics.

Fixes #55.