### PR TITLE
SingleLoopTransform: Deal with alien variables in validity witnesses in backtranslation

### DIFF
--- a/test/test_TPA.cc
+++ b/test/test_TPA.cc
@@ -670,8 +670,7 @@ TEST_F(TPATest, test_TPA_BeyondTransitionSystemDAG_Safe)
             ChcBody{{logic->mkOr(logic->mkLt(y, zero), logic->mkLt(x, zero))}, {UninterpretedPredicate{current1}}}
         }};
     TPAEngine engine(*logic, options);
-    // TODO: Enable validation once we deal with alien variables in vertex invariants properly
-    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(TPATest, test_TPA_BeyondTransitionSystemDAG_Branching_Unsafe)


### PR DESCRIPTION
In the current encoding to single transition system, when translating edge constraint, we do not put any restriction on the big system's state variables that do no correspond to the variables of the target node. This means that when we encounter alien variables during backtranslation of validity witness, we can universally quantify these variables to obtain predicate representation only over its arguments. We can then apply quantifier elimination.
Since QE works on existential quantifiers, we have to first negate the original invariant and then negate again after QE.

Fixes #45.