### PR TITLE
Alethe: Fix handling of nullary predicates

### DIFF
--- a/src/proofs/ProofSteps.cc
+++ b/src/proofs/ProofSteps.cc
@@ -246,12 +246,11 @@ void StepHandler::buildAletheProof() {
             auto simplifiedLHSderivationStep = deriveLHSWithoutConstraint(simplifiedLHS, std::move(requiredMP));
             // Now we have that LHS = simplifiedLHS and we have derived simplified LHS, from these we can derive the
             // original LHS
-            notifyObservers(Step(currentStep, Step::STEP,
-                                 packClause(negate(originalSimplifiedEquality), renamedImpLHS, negate(simplifiedLHS)),
-                                 "equiv_pos1"));
+            notifyObservers(Step(currentStep, Step::STEP, packClause(renamedImpLHS, negate(simplifiedLHS)), "equiv2",
+                                 std::vector<std::size_t>{equalityStep}));
             ++currentStep;
             notifyObservers(Step(currentStep, Step::STEP, packClause(renamedImpLHS), "resolution",
-                                 std::vector<std::size_t>{currentStep - 1, equalityStep, simplifiedLHSderivationStep}));
+                                 std::vector<std::size_t>{simplifiedLHSderivationStep, currentStep - 1}));
             ++currentStep;
             LHSderivationStep = currentStep - 1;
 
@@ -278,11 +277,11 @@ void StepHandler::buildAletheProof() {
             auto simplifiedRHS = equivalence->getArgs()[1];
             assert(simplifiedRHS->printTerm() == logic.printTerm(step.derivedFact));
             // The last step is that RHS is equivalent to the simplified RHS. From that we can derive the simplified RHS
-            notifyObservers(Step(currentStep, Step::STEP,
-                                 packClause(negate(equivalence), negate(implicationRHS), simplifiedRHS), "equiv_pos2"));
+            notifyObservers(Step(currentStep, Step::STEP, packClause(negate(implicationRHS), simplifiedRHS), "equiv1",
+                                 std::vector<std::size_t>{currentStep - 1}));
             ++currentStep;
             notifyObservers(Step(currentStep, Step::STEP, packClause(simplifiedRHS), "resolution",
-                                 std::vector<std::size_t>{currentStep - 1, currentStep - 2, RHSderivationStep}));
+                                 std::vector<std::size_t>{currentStep - 1, RHSderivationStep}));
             ++currentStep;
         }
 

--- a/src/proofs/ProofSteps.cc
+++ b/src/proofs/ProofSteps.cc
@@ -410,10 +410,13 @@ std::size_t StepHandler::deriveLHSWithoutConstraint(std::shared_ptr<Term> const 
         notifyObservers(
             Step(currentStep, Step::STEP, packClause(simplifiedLHS), "resolution", std::move(predicatePremises)));
         return currentStep++;
-    } else if (simplifiedLHS->getTermType() == Term::APP) { // single predicate
+    } else if (simplifiedLHS->getTermType() == Term::APP or
+               (simplifiedLHS->getTermType() == Term::TERMINAL and simplifiedLHS->getTerminalType() == Term::VAR)) {
+        // single predicate, including 0-ary predicate as a special case
         assert(predicatePremises.size() == 1);
         return predicatePremises[0];
-    } else if (simplifiedLHS->getTermType() == Term::TERMINAL) { // no predicate => constant true
+    } else if (simplifiedLHS->getTermType() == Term::TERMINAL and simplifiedLHS->getTerminalType() == Term::BOOL) {
+        // no predicate => constant true
         assert(simplifiedLHS->printTerm() == "true");
         return getOrCreateTrueStep();
     } else {

--- a/test/prooftesting/predicate_without_args.smt2
+++ b/test/prooftesting/predicate_without_args.smt2
@@ -1,0 +1,39 @@
+; ./prepared/hcai/./svcomp/O3/id_o3_false-unreach-call_000.smt2
+(set-logic HORN)
+
+
+(declare-fun |main@entry| ( Int ) Bool)
+(declare-fun |main@id.exit.split| ( ) Bool)
+
+(assert
+  (forall ( (A Int) ) 
+    (=>
+      (and
+        true
+      )
+      (main@entry A)
+    )
+  )
+)
+(assert
+  (forall ( (A Int) ) 
+    (=>
+      (main@entry A)
+      main@id.exit.split
+    )
+  )
+)
+(assert
+  (forall ( (CHC_COMP_UNUSED Bool) ) 
+    (=>
+      (and
+        main@id.exit.split
+        true
+      )
+      false
+    )
+  )
+)
+
+(check-sat)
+(exit)


### PR DESCRIPTION
The changes in #62 broke proofs for systems with nullary predicates. This PR fixes handling of this case.
Moreover, it uses simpler rule to derive one side of an equivalence from the equivalence itself and the other side.