### PR TITLE
Spacer: Avoid creating unnecessary terms

### DIFF
--- a/src/engine/Spacer.cc
+++ b/src/engine/Spacer.cc
@@ -208,18 +208,18 @@ class SpacerContext {
     bool tryPushComponents(SymRef, std::size_t, PTRef);
 
 
-    enum class QueryAnswer : char {UNKNOWN, VALID, INVALID, ERROR};
+    enum class QueryAnswer : char {UNKNOWN, SAT, UNSAT, ERROR};
     struct QueryResult {
         QueryAnswer answer;
         std::unique_ptr<Model> model;
     };
-    QueryResult implies(PTRef antecedent, PTRef consequent) const;
+    QueryResult sat(PTRef A, PTRef B) const;
 
     struct ItpQueryResult {
         QueryAnswer answer;
         PTRef interpolant = PTRef_Undef;
     };
-    ItpQueryResult interpolatingImplies(PTRef antecedent, PTRef consequent);
+    ItpQueryResult interpolatingSat(PTRef A, PTRef B);
 
     bool checkMustReachability(std::vector<EId> const & edges, ProofObligation const & pob);
 
@@ -342,9 +342,9 @@ SpacerContext::BoundedSafetyResult SpacerContext::boundSafety(std::size_t curren
             for (EId eid : edges) {
                 edgeRepresentations.push(getEdgeMaySummary(eid, pob.bound - 1));
             }
-            auto res = interpolatingImplies(logic.mkOr(edgeRepresentations), logic.mkNot(pob.constraint));
-            assert(res.answer == QueryAnswer::VALID);
-            if (res.answer != QueryAnswer::VALID) {
+            auto res = interpolatingSat(logic.mkOr(edgeRepresentations), pob.constraint);
+            assert(res.answer == QueryAnswer::UNSAT);
+            if (res.answer != QueryAnswer::UNSAT) {
                 throw std::logic_error("All edges should have been blocked, but they are not!");
             }
             PTRef newLemma = VersionManager(logic).targetFormulaToBase(res.interpolant);
@@ -364,23 +364,23 @@ SpacerContext::BoundedSafetyResult SpacerContext::boundSafety(std::size_t curren
     return BoundedSafetyResult::SAFE; // not reachable at this bound
 }
 
-SpacerContext::QueryResult SpacerContext::implies(PTRef antecedent, PTRef consequent) const {
+SpacerContext::QueryResult SpacerContext::sat(PTRef A, PTRef B) const {
     QueryResult qres;
-    if (antecedent == logic.getTerm_false()) {
-        qres.answer = QueryAnswer::VALID;
+    if (A == logic.getTerm_false()) {
+        qres.answer = QueryAnswer::UNSAT;
         return qres;
     }
     SMTSolver solverWrapper(logic);
     auto & solver = solverWrapper.getCoreSolver();
-    solver.insertFormula(antecedent);
-    solver.insertFormula(logic.mkNot(consequent));
+    solver.insertFormula(A);
+    solver.insertFormula(B);
     auto res = solver.check();
     if (res == s_True) {
-        qres.answer = QueryAnswer::INVALID;
+        qres.answer = QueryAnswer::SAT;
         qres.model = solver.getModel();
     }
     else if (res == s_False) {
-        qres.answer = QueryAnswer::VALID;
+        qres.answer = QueryAnswer::UNSAT;
     }
     else if (res == s_Undef) {
         qres.answer = QueryAnswer::UNKNOWN;
@@ -395,19 +395,19 @@ SpacerContext::QueryResult SpacerContext::implies(PTRef antecedent, PTRef conseq
     return qres;
 }
 
-SpacerContext::ItpQueryResult SpacerContext::interpolatingImplies(PTRef antecedent, PTRef consequent) {
+SpacerContext::ItpQueryResult SpacerContext::interpolatingSat(PTRef A, PTRef B) {
     SMTSolver solverWrapper(logic, SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
     solverWrapper.getConfig().setSimplifyInterpolant(4);
     auto & solver = solverWrapper.getCoreSolver();
-    solver.insertFormula(antecedent);
-    solver.insertFormula(logic.mkNot(consequent));
+    solver.insertFormula(A);
+    solver.insertFormula(B);
     auto res = solver.check();
     ItpQueryResult qres;
     if (res == s_True) {
-        qres.answer = QueryAnswer::INVALID;
+        qres.answer = QueryAnswer::SAT;
     }
     else if (res == s_False) {
-        qres.answer = QueryAnswer::VALID;
+        qres.answer = QueryAnswer::UNSAT;
         auto itpCtx = solver.getInterpolationContext();
         std::vector<PTRef> itps;
         ipartitions_t mask = 1;
@@ -437,21 +437,21 @@ bool SpacerContext::checkMustReachability(std::vector<EId> const & edges, ProofO
         summaries.push(getEdgeMustSummary(edgeId, pob.bound - 1));
     }
     PTRef anySummary = logic.mkOr(summaries);
-    auto implCheckRes = implies(anySummary, logic.mkNot(pob.constraint));
-    if (implCheckRes.answer == SpacerContext::QueryAnswer::INVALID) {
+    auto checkRes = sat(anySummary, pob.constraint);
+    if (checkRes.answer == SpacerContext::QueryAnswer::SAT) {
         TRACE(1, "Must summary successfully applied!")
-        assert(implCheckRes.model);
+        assert(checkRes.model);
         // eliminate variables from body except variables present in predicate of pob's vertex
         auto predicateVars = TermUtils(logic).getVars(graph.getNextStateVersion(pob.vertex));
         int counter = 0;
         for (PTRef summary : summaries) {
-            if (implCheckRes.model->evaluate(summary) == logic.getTerm_true()) {
-                PTRef newMustSummary = projectFormula(summary, predicateVars, *implCheckRes.model);
+            if (checkRes.model->evaluate(summary) == logic.getTerm_true()) {
+                PTRef newMustSummary = projectFormula(summary, predicateVars, *checkRes.model);
                 assert(newMustSummary != PTRef_Undef);
                 PTRef definitelyReachable = VersionManager(logic).targetFormulaToBase(newMustSummary);
                 addMustSummary(pob.vertex, pob.bound, definitelyReachable);
                 if (logProof) {
-                    logNewFactIntoDatabase(definitelyReachable, pob.vertex, pob.bound - 1, edges[counter], *implCheckRes.model);
+                    logNewFactIntoDatabase(definitelyReachable, pob.vertex, pob.bound - 1, edges[counter], *checkRes.model);
                 }
                 return true;
             }
@@ -466,11 +466,11 @@ bool SpacerContext::checkMustReachability(std::vector<EId> const & edges, ProofO
 bool SpacerContext::mayReachable(EId eid, PTRef targetConstraint, std::size_t bound) const {
     PTRef maySummary = getEdgeMaySummary(eid, bound);
     if (maySummary == logic.getTerm_false()) { return false; }
-    auto implCheckRes = implies(maySummary, logic.mkNot(targetConstraint));
-    if (implCheckRes.answer != SpacerContext::QueryAnswer::INVALID and implCheckRes.answer != SpacerContext::QueryAnswer::VALID) {
+    auto checkRes = sat(maySummary, targetConstraint);
+    if (checkRes.answer != SpacerContext::QueryAnswer::SAT and checkRes.answer != SpacerContext::QueryAnswer::UNSAT) {
         throw std::logic_error("Spacer: Error in checking implication in mayReachable");
     }
-    return implCheckRes.answer == SpacerContext::QueryAnswer::INVALID;
+    return checkRes.answer == SpacerContext::QueryAnswer::SAT;
 }
 
 std::optional<ProofObligation> SpacerContext::computePredecessor(EId eid, ProofObligation const & pob) const {
@@ -480,8 +480,8 @@ std::optional<ProofObligation> SpacerContext::computePredecessor(EId eid, ProofO
     assert(not sources.empty());
     if (sources.size() == 1) { // Edge with single source, we only need to check if pob is reachable with over-approximation
         PTRef maySummary = getEdgeMaySummary(eid, sourceBound);
-        auto res = implies(maySummary, logic.mkNot(pob.constraint));
-        if (res.answer == QueryAnswer::INVALID) {
+        auto res = sat(maySummary, pob.constraint);
+        if (res.answer == QueryAnswer::SAT) {
             assert(res.model);
             // When this source is over-approximated and the edge becomes feasible -> extract next proof obligation
             auto source = sources[0];
@@ -490,7 +490,7 @@ std::optional<ProofObligation> SpacerContext::computePredecessor(EId eid, ProofO
             PTRef newPob = VersionManager(logic).sourceFormulaToTarget(newConstraint); // ensure POB is target fla
             TRACE(2, "New proof obligation generated")
             return ProofObligation{source, sourceBound, newPob};
-        } else if (res.answer == QueryAnswer::VALID) {
+        } else if (res.answer == QueryAnswer::UNSAT) {
             TRACE(2, "Edge blocked by current may-summaries")
             return std::nullopt;
         }
@@ -511,8 +511,8 @@ std::optional<ProofObligation> SpacerContext::computePredecessor(EId eid, ProofO
     std::size_t vertexToRefine = 0; // vertex that is the last one to be over-approximated
     while(true) {
         PTRef mixedEdgeSummary = getEdgeMixedSummary(eid, sourceBound, vertexToRefine);
-        auto res = implies(mixedEdgeSummary, logic.mkNot(pob.constraint));
-        if (res.answer == QueryAnswer::INVALID) {
+        auto res = sat(mixedEdgeSummary, pob.constraint);
+        if (res.answer == QueryAnswer::SAT) {
             assert(res.model);
             // When this source is over-approximated and the edge becomes feasible -> extract next proof obligation
             auto source = sources[vertexToRefine];
@@ -521,7 +521,7 @@ std::optional<ProofObligation> SpacerContext::computePredecessor(EId eid, ProofO
             PTRef newPob = VersionManager(logic).sourceFormulaToTarget(newConstraint); // ensure POB is target fla
             TRACE(2, "New proof obligation generated")
             return ProofObligation{sources[vertexToRefine], sourceBound, newPob};
-        } else if (res.answer == QueryAnswer::VALID) {
+        } else if (res.answer == QueryAnswer::UNSAT) {
             // Continue with the next vertex to refine
             ++vertexToRefine;
             assert(vertexToRefine < sources.size());
@@ -773,7 +773,6 @@ void computePremiseInstances(DerivationDatabase::Entry const & databaseEntry, En
     //  2. Premise constraints
     //  3. The fact we want to derive
     // This will give us a model from which we can compute the instances of the premises
-
     assert(entry.premiseInstances.empty());
     Logic & logic = graph.getLogic();
     EId edge = databaseEntry.incomingEdge;


### PR DESCRIPTION
Since OpenSMT does not garbage-collect unused terms, we have to be more careful with creating unnecessary terms.
When the number of terms grows too large (in the order of hundred of thousands), it causes slowdown in OpenSMT in surprising places. Namely, OpenSMT in some places creates a vector with size equal to the number of all known terms, even though it actually needs to remember some information for only a tiny fraction of all the terms.
This starts to show in performance investigations in Golem, where we often create large number of very simple queries.

This PR avoids term creation in two places in Spacer.

1. When testing local reachability, we avoid creating unnecessary negations for proof obligations.
2. In proof production, we avoid creating unnecessary equalities, equating variables with their values (when we can just directly simplify the rest of the query with these substitutions).

More details are in the individual commit messages.