### PR TITLE
BMC: Simplify and improve the algorithm for solving general linear systems

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -3,6 +3,8 @@ src/TransformationUtils.h
 src/ChcInterpreter.cc
 src/ChcInterpreter.h
 
+src/engine/Bmc.cc
+src/engine/Bmc.h
 src/engine/IMC.cc
 src/engine/IMC.h
 src/engine/TPA.cc

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -24,7 +24,6 @@ const std::string Options::VERBOSE = "verbose";
 const std::string Options::TPA_USE_QE = "tpa.use-qe";
 const std::string Options::FORCE_TS = "force-ts";
 const std::string Options::PROOF_FORMAT = "proof-format";
-const std::string Options::EXPERIMENTAL = "experimental";
 
 namespace{
 
@@ -75,7 +74,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     int tpaUseQE = 0;
     int printVersion = 0;
     int forceTS = 0;
-    int experimental = 0;
 
     struct option long_options[] =
         {
@@ -94,7 +92,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
             {Options::TPA_USE_QE.c_str(), optional_argument, &tpaUseQE, 1},
             {Options::PROOF_FORMAT.c_str(), required_argument, nullptr, 'p'},
             {Options::FORCE_TS.c_str(), no_argument, &forceTS, 1},
-            {Options::EXPERIMENTAL.c_str(), no_argument, &experimental, 1},
             {0, 0, 0, 0}
         };
 
@@ -184,9 +181,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     }
     if (forceTS) {
         res.addOption(Options::FORCE_TS, "true");
-    }
-    if (experimental) {
-        res.addOption(Options::EXPERIMENTAL, "true");
     }
     res.addOption(Options::LRA_ITP_ALG, std::to_string(lraItpAlg));
     res.addOption(Options::VERBOSE, std::to_string(verbose));

--- a/src/Options.h
+++ b/src/Options.h
@@ -46,7 +46,6 @@ public:
     static const std::string VERBOSE;
     static const std::string TPA_USE_QE;
     static const std::string FORCE_TS;
-    static const std::string EXPERIMENTAL;
 };
 
 class CommandLineParser {

--- a/src/engine/Bmc.cc
+++ b/src/engine/Bmc.cc
@@ -77,24 +77,35 @@ TransitionSystemVerificationResult BMC::solveTransitionSystemInternal(Transition
 namespace {
 constexpr const char * auxName = "golem_bmc";
 
+class BMCUtils {
+public:
+    explicit BMCUtils(Logic & logic) : logic(logic) {}
+
+    PTRef getVarFor(SymRef node, std::size_t step) {
+        return logic.mkBoolVar((auxName + std::to_string(node.x) + '#' + std::to_string(step)).c_str());
+    }
+private:
+    Logic & logic;
+};
+
 InvalidityWitness computeWitness(ChcDirectedGraph const & graph, Model & model, std::size_t const steps, std::unordered_set<PTRef, PTRefHash> const & knownNodes) {
     auto adjacencyLists = AdjacencyListsGraphRepresentation::from(graph);
     Logic & logic = graph.getLogic();
-    auto getVarFor = [&](SymRef node, std::size_t step) {
-        return logic.mkBoolVar((auxName + std::to_string(node.x) + '#' + std::to_string(step)).c_str());
-    };
+    PTRef trueT = logic.getTerm_true();
+    BMCUtils utils(logic);
     std::vector<EId> errorPath;
-    PTRef errorReached = getVarFor(graph.getExit(), steps);
-    if (model.evaluate(errorReached) != logic.getTerm_true()) { return {}; }
+    PTRef errorReached = utils.getVarFor(graph.getExit(), steps);
+    if (model.evaluate(errorReached) != trueT) { return {}; }
     auto current = graph.getExit();
     auto remaining = steps;
     while (remaining > 0) {
         // figure out the predecessor;
         for (auto eid : adjacencyLists.getIncomingEdgesFor(current)) {
             auto source = graph.getSource(eid);
-            PTRef reached = getVarFor(source, remaining - 1);
+            PTRef reached = utils.getVarFor(source, remaining - 1);
             if (knownNodes.find(reached) == knownNodes.end()) { continue; }
-            if (model.evaluate(reached) == logic.getTerm_true()) {
+            if (model.evaluate(reached) == trueT and model.evaluate(TimeMachine(logic).sendFlaThroughTime(
+                                                         graph.getEdgeLabel(eid), remaining - 1)) == trueT) {
                 errorPath.push_back(eid);
                 current = source;
                 break; // the for loop
@@ -112,98 +123,72 @@ InvalidityWitness computeWitness(ChcDirectedGraph const & graph, Model & model, 
  * Algorithm to check linear system of CHCs using a single solver.
  *
  * The algorithm maintains a frontier of reachable nodes for each level l and in each iteration computes
- * the next frontier for level l+1. When an edge to an error node is encountered, the solver checks
- * the feasibility of traversing the edge.
+ * the next frontier for level l+1.
  *
  * The algorithm uses auxiliary boolean variables n_l to track if a node n is reached at level l.
- * We use this because we do not unroll into a tree, but into a DAG, with multiple possible paths to the same node.
- * The auxiliary variables are used to ensure that if a node n is reached at level l, then some successor must be
- * reached at level l+1. Similarly, if a node is reached at level l+1 then one of its predecessors must be reached
- * at level l.
+ * We constain the search in the solver with conditions that if  a node is reached at level l+1 then
+ * one of its predecessors must be reached at level l.
  * The auxiliary variables also help to extract the feasible path.
- *
- * However, with these extra conditions we need to check true reachability of every node we want to add to the frontier.
- * Otherwise, it would make the whole unrolled DAG infeasible.
  *
  * TODO: Figure out a way to avoid these extra checks
  *
  * Preconditions:
  *  - There are no multiedges (No target can be reached from the same source by two different edges)
- *  - There are no inconsistent edges 
  */
 VerificationResult BMC::solveGeneralLinearSystem(ChcDirectedGraph const & graph) {
     if (verbosity > 0) { std::cout << "BMC: Solving general system!" << std::endl; }
     Logic & logic = graph.getLogic();
-    auto getVarFor = [&](SymRef node, std::size_t step) {
-        return logic.mkBoolVar((auxName + std::to_string(node.x) + '#' + std::to_string(step)).c_str());
-    };
+    BMCUtils utils(logic);
     auto adjacencyLists = AdjacencyListsGraphRepresentation::from(graph);
     TimeMachine tm(logic);
-    std::unordered_set<SymRef, SymRefHash> frontier;
+    std::unordered_set<SymRef, SymRefHash> frontier, nextFrontier;
     frontier.insert(graph.getEntry());
-    std::unordered_map<SymRef, PTRef, SymRefHash> nextFrontier;
     SMTSolver solver(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
+    auto allnodes = graph.getVertices();
+    std::size_t maxLoopUnrollings = std::numeric_limits<int>::max() - 1;
 
     // TODO: Figure out how to compute CEX withtout this. Maybe OpenSMT should have a model that does not use default values?
     std::unordered_set<PTRef, PTRefHash> encounteredNodes;
     {
-        PTRef entry = getVarFor(graph.getEntry(), 0u);
+        PTRef entry = utils.getVarFor(graph.getEntry(), 0u);
         solver.getCoreSolver().insertFormula(entry);
         encounteredNodes.insert(entry);
     }
-    std::size_t maxLoopUnrollings = std::numeric_limits<std::size_t>::max() - 1;
-    for(std::size_t currentUnrolling = 0u; currentUnrolling < maxLoopUnrollings; ++currentUnrolling) {
-        for (auto node : frontier) {
-            PTRef currentNodeReached = getVarFor(node, currentUnrolling);
-            vec<PTRef> nextTransitions;
-            for (EId eid : adjacencyLists.getOutgoingEdgesFor(node)) {
-                auto target = graph.getTarget(eid);
-                PTRef transition = tm.sendFlaThroughTime(graph.getEdgeLabel(eid), currentUnrolling);
-                PTRef nextTargetReached = getVarFor(target, currentUnrolling + 1);
-                nextTransitions.push(logic.mkAnd(transition, nextTargetReached));
-                nextFrontier.emplace(target, nextTargetReached);
-            }
-            solver.getCoreSolver().insertFormula(logic.mkImpl(currentNodeReached, logic.mkOr(nextTransitions)));
-        }
-
-        for (auto const & [node, nodeReached] : nextFrontier) {
+    for (std::size_t currentUnrolling = 0u; currentUnrolling < maxLoopUnrollings; ++currentUnrolling) {
+        nextFrontier.clear();
+        bool exitEncountered = false;
+        for (auto node : allnodes) {
             vec<PTRef> predecessorTransitions;
             for (EId eid : adjacencyLists.getIncomingEdgesFor(node)) {
                 auto source = graph.getSource(eid);
                 if (frontier.find(source) == frontier.end()) { continue; }
-                PTRef sourceReached = getVarFor(source, currentUnrolling);
-                PTRef transition = tm.sendFlaThroughTime(graph.getEdgeLabel(eid), currentUnrolling);
+                PTRef sourceReached = utils.getVarFor(source, currentUnrolling);
+                PTRef transition = tm.sendFlaThroughTime(graph.getEdgeLabel(eid), static_cast<int>(currentUnrolling));
                 predecessorTransitions.push(logic.mkAnd(transition, sourceReached));
             }
-            solver.getCoreSolver().insertFormula(logic.mkImpl(nodeReached, logic.mkOr(predecessorTransitions)));
+            if (predecessorTransitions.size() > 0) {
+                exitEncountered |= node == graph.getExit();
+                PTRef nodeReached = utils.getVarFor(node, currentUnrolling + 1);
+                solver.getCoreSolver().insertFormula(logic.mkImpl(nodeReached, logic.mkOr(predecessorTransitions)));
+                nextFrontier.insert(node);
+                encounteredNodes.insert(nodeReached);
+            }
         }
-        frontier.clear();
-        std::vector<PTRef> notReached;
-        std::transform(nextFrontier.begin(), nextFrontier.end(), std::back_inserter(notReached),
-                       [&](auto const & entry) { return logic.mkNot(entry.second); });
-        for (auto const & [node, nodeReached] : nextFrontier) {
+        if (exitEncountered) {
             // TODO: Implement check-sat-assuming in OpenSMT
-            PTRef nodeNotReached = logic.mkNot(nodeReached);
-            auto it = std::find(notReached.begin(), notReached.end(), nodeNotReached);
-            assert(it != notReached.end());
-            *it = nodeReached;
+            PTRef exitReached = utils.getVarFor(graph.getExit(), currentUnrolling + 1);
             solver.getCoreSolver().push();
-            solver.getCoreSolver().insertFormula(logic.mkAnd(notReached));
-            *it = nodeNotReached;
+            solver.getCoreSolver().insertFormula(exitReached);
             auto res = solver.getCoreSolver().check();
-            if (node == graph.getExit() and res == s_True) {
+            if (res == s_True) {
+                if (verbosity > 0) { std::cout << "; BMC: Bug found in depth: " << currentUnrolling << std::endl; }
                 if (not needsWitness) { return {VerificationAnswer::UNSAFE, NoWitness{}}; }
                 return {VerificationAnswer::UNSAFE, computeWitness(graph, *solver.getCoreSolver().getModel(), currentUnrolling + 1, encounteredNodes)};
             }
-            if (res != s_False) {
-                frontier.insert(node);
-                encounteredNodes.insert(nodeReached);
-            }
             solver.getCoreSolver().pop();
         }
-        nextFrontier.clear();
-        if (frontier.empty()) { return VerificationResult(VerificationAnswer::SAFE); }
         if (verbosity > 1) { std::cout << "; BMC: No path of length " << currentUnrolling << " found!" << std::endl; }
+        std::swap(frontier, nextFrontier);
     }
     return VerificationResult(VerificationAnswer::UNKNOWN);
 }

--- a/src/engine/Bmc.h
+++ b/src/engine/Bmc.h
@@ -21,7 +21,7 @@ public:
     BMC(Logic & logic, Options const & options) : logic(logic) {
         needsWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
         verbosity = std::stoi(options.getOrDefault(Options::VERBOSE, "0"));
-        forceTransitionSystem = options.getOrDefault(Options::EXPERIMENTAL, "") != "true";
+        forceTransitionSystem = options.getOrDefault(Options::FORCE_TS, "") == "true";
     }
 
     VerificationResult solve(ChcDirectedHyperGraph const & graph) override {

--- a/src/engine/Bmc.h
+++ b/src/engine/Bmc.h
@@ -12,12 +12,12 @@
 
 class BMC : public Engine {
     Logic & logic;
-//    Options const & options;
+    // Options const & options;
     bool needsWitness = false;
     int verbosity = 0;
     bool forceTransitionSystem = true;
-public:
 
+public:
     BMC(Logic & logic, Options const & options) : logic(logic) {
         needsWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
         verbosity = std::stoi(options.getOrDefault(Options::VERBOSE, "0"));
@@ -40,5 +40,4 @@ private:
     VerificationResult solveGeneralLinearSystem(ChcDirectedGraph const & graph);
 };
 
-
-#endif //GOLEM_BMC_H
+#endif // GOLEM_BMC_H


### PR DESCRIPTION
This is inspired by the implementation in Z3.
The main idea is that we only need to assert that if we reach some node
in step l+1, then we must have used one of the incoming edges (clauses
where this node is a head) and we must have been in the source of the
edge in step l.
(We also assert that we start at entry at step 0.)
Then we check for each step if we can be in the exit node.
These conditions are sufficient, we do not need the constraints about
forward reachability (if I am at some node then I need to be in one of
its successors in the next step).