### PR TITLE
First version of the algorithm Dual Approximated Reachability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
     formatter:
       docker:
-        - image: usiverify/verify-env:current
+        - image: usiverify/verify-env:archlinux
           auth:
             username: mydockerhub-user
             password: $DOCKERHUB_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
         - checkout
         - run:
             name: run clang formatter
-            command: cat .clang-files | xargs clang-format --Werror --dry-run
+            command: |
+              clang-format --version
+              cat .clang-files | xargs clang-format --Werror --dry-run
 
     build-recent-gcc-debug:
         docker:

--- a/.clang-files
+++ b/.clang-files
@@ -5,6 +5,8 @@ src/ChcInterpreter.h
 
 src/engine/Bmc.cc
 src/engine/Bmc.h
+src/engine/DAR.cc
+src/engine/DAR.h
 src/engine/IMC.cc
 src/engine/IMC.h
 src/engine/TPA.cc

--- a/README.md
+++ b/README.md
@@ -38,22 +38,26 @@ BMC engine implements the simple bounded model checking algorithm which checks f
 It uses incremental capibilities of the underlying SMT solver to speed up the process.
 Works only for linear systems of Horn clauses.
 
-### McMillan's Interpolation-based model checking
+### Dual Approximated Reachability
 
-IMC engine implements the original McMillan's interpolation-based model-checking algorithm from [this paper](https://link.springer.com/chapter/10.1007/978-3-540-45069-6_1).
-It works on transition system, but it can handle linear systems of Horn clauses by first transforming them into a simple transition system.
+DAR engine implements the algorithm Dual Approximated Reachability described in [this paper](https://link.springer.com/chapter/10.1007/978-3-642-36742-7_22).
+It works only for linear systems of Horn clauses. 
 
 ### k-induction
 
 KIND engine implements very basic k-induction algorithm from [this paper](https://link.springer.com/chapter/10.1007/3-540-40922-X_8).
 It only supports transition systems.
 
-
 ### Lazy Abstraction With Interpolants (Impact)
 
 The implementation of LAWI follows the description of the algorithm in [this paper](https://link.springer.com/chapter/10.1007/11817963_14).
 The algorithm is also known as `Impact`, which was the first tool where the algorithm was implemented.
 Works only for linear systems of Horn clauses.
+
+### McMillan's Interpolation-based model checking
+
+IMC engine implements the original McMillan's interpolation-based model-checking algorithm from [this paper](https://link.springer.com/chapter/10.1007/978-3-540-45069-6_1).
+It works on transition system, but it can handle linear systems of Horn clauses by first transforming them into a simple transition system.
 
 ### Predicate Abstraction and CEGAR
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(golem_lib
     PRIVATE ChcInterpreter.cc
     PRIVATE engine/Bmc.cc
     PRIVATE engine/Common.cc
+    PRIVATE engine/DAR.cc
     PRIVATE engine/EngineFactory.cc
     PRIVATE engine/IMC.cc
     PRIVATE engine/Kind.cc

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -36,6 +36,7 @@ void printUsage() {
         "-l,--logic <name>          SMT-LIB logic to use (required); possible values: QF_LRA, QF_LIA\n"
         "-e,--engine <name>         Select engine to use; supported engines:\n"
         "                               bmc - Bounded Model Checking (only linear systems)\n"
+        "                               dar - Dual Approximated Reachability (only linear systems)\n"
         "                               imc - McMillan's original Interpolation-based model checking (only linear systems)\n"
         "                               kind - basic k-induction algorithm (only transition systems)\n"
         "                               lawi - Lazy Abstraction with Interpolants (only linear systems)\n"

--- a/src/engine/DAR.cc
+++ b/src/engine/DAR.cc
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "DAR.h"
+
+#include "Common.h"
+#include "TransformationUtils.h"
+
+#include "transformers/SingleLoopTransformation.h"
+#include "utils/SmtSolver.h"
+
+VerificationResult DAR::solve(ChcDirectedGraph const & graph) {
+    if (isTrivial(graph)) { return solveTrivial(graph); }
+    if (isTransitionSystem(graph)) { return solveTransitionSystem(graph); }
+    SingleLoopTransformation transformation;
+    auto [ts, backtranslator] = transformation.transform(graph);
+    assert(ts);
+    auto res = solveTransitionSystemInternal(*ts);
+    return computeWitness ? backtranslator->translate(res) : VerificationResult(res.answer);
+}
+
+VerificationResult DAR::solveTransitionSystem(ChcDirectedGraph const & graph) {
+    auto ts = toTransitionSystem(graph);
+    auto res = solveTransitionSystemInternal(*ts);
+    return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
+}
+
+class DualApproximatedReachability {
+public:
+    explicit DualApproximatedReachability(TransitionSystem const & ts)
+        : ts(ts), forward{ts.getInit()}, backward{ts.getQuery()} {}
+
+    TransitionSystemVerificationResult run();
+
+private:
+    using Sequence = std::vector<PTRef>;
+
+    bool localStrengthen();
+
+    bool globalStrengthen();
+
+    std::optional<PTRef> fixpoint() const;
+
+    void iterativeLocalStrengthening(std::size_t forwardIndex);
+
+    PTRef interpolateForward(std::size_t forwardIndex);
+
+    PTRef interpolateBackward(std::size_t backwardIndex);
+
+    SMTSolver::Answer checkSat(PTRef fla) const;
+
+    [[nodiscard]] Logic & logic() const { return ts.getLogic(); }
+
+    TransitionSystem const & ts;
+    Sequence forward{};
+    Sequence backward{};
+    std::size_t n{0};
+
+    void showSequences() const;
+};
+
+TransitionSystemVerificationResult DAR::solveTransitionSystemInternal(TransitionSystem const & system) {
+    { // Check satisfiability of Init /\ Query
+        SMTSolver solver(logic, SMTSolver::WitnessProduction::NONE);
+        solver.assertProp(system.getInit());
+        solver.assertProp(system.getQuery());
+        if (solver.check() == SMTSolver::Answer::SAT) {
+            return TransitionSystemVerificationResult{VerificationAnswer::UNSAFE, 0u};
+        }
+    }
+    return DualApproximatedReachability(system).run();
+}
+
+TransitionSystemVerificationResult DualApproximatedReachability::run() {
+    assert(n == 0 and forward.size() == 1 and backward.size() == 1);
+    // Handle first iteration specially
+    {
+        TimeMachine tm(logic());
+        SMTSolver solver(logic(), SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+        solver.assertProp(ts.getInit());
+        solver.assertProp(ts.getTransition());
+        solver.assertProp(tm.sendFlaThroughTime(ts.getQuery(), 1));
+        auto res = solver.check();
+        if (res == SMTSolver::Answer::SAT) {
+            return TransitionSystemVerificationResult{VerificationAnswer::UNSAFE, 1u};
+        }
+        if (res != SMTSolver::Answer::UNSAT) {
+            return TransitionSystemVerificationResult{VerificationAnswer::UNKNOWN, 0u};
+        }
+        vec<PTRef> itps;
+        auto itpContext = solver.getInterpolationContext();
+        itpContext->getSingleInterpolant(itps, 3);
+        itpContext->getSingleInterpolant(itps, 6);
+        assert(itps.size() == 2);
+        forward.push_back(tm.sendFlaThroughTime(itps[0], -1));
+        backward.push_back(itps[1]);
+        ++n;
+    }
+    while (true) {
+        // std:: cout << "Step " << n << std::endl;
+        // showSequences();
+        if (localStrengthen() == false) {
+            if (globalStrengthen() == false) {
+                return TransitionSystemVerificationResult{VerificationAnswer::UNSAFE, n + 1};
+            }
+        }
+        ++n;
+        auto maybeInvariant = fixpoint();
+        if (maybeInvariant) {
+            return TransitionSystemVerificationResult{VerificationAnswer::SAFE, maybeInvariant.value()};
+        }
+    }
+}
+
+bool DualApproximatedReachability::localStrengthen() {
+    assert(forward.size() == backward.size());
+    assert(forward.size() == n + 1);
+    Logic & logic = ts.getLogic();
+    // Find a pair F_i, B_j (j = n - i) are not connected by one step, iterate backwards
+    auto maybeIndex = [&]() -> std::optional<std::size_t> {
+        for (std::size_t j = 0; j < n; ++j) {
+            auto i = n - j;
+            auto res = checkSat(
+                logic.mkAnd({forward[i], ts.getTransition(), TimeMachine(logic).sendFlaThroughTime(backward[j], 1)}));
+            if (res == SMTSolver::Answer::UNSAT) { return i; }
+        }
+        return std::nullopt;
+    }();
+    if (not maybeIndex) { return false; }
+    iterativeLocalStrengthening(maybeIndex.value());
+    return true;
+}
+
+void DualApproximatedReachability::iterativeLocalStrengthening(std::size_t forwardIndex) {
+    std::size_t backwardIndex = n - forwardIndex;
+    TimeMachine tm(logic());
+    while (forwardIndex < n) {
+        PTRef itp = interpolateForward(forwardIndex);
+        itp = tm.sendFlaThroughTime(itp, -1);
+        forward[forwardIndex + 1] = logic().mkAnd(forward[forwardIndex + 1], itp);
+        ++forwardIndex;
+    }
+    PTRef newStep = interpolateForward(n);
+    forward.push_back(tm.sendFlaThroughTime(newStep, -1));
+    while (backwardIndex < n) {
+        PTRef itp = interpolateBackward(backwardIndex);
+        backward[backwardIndex + 1] = logic().mkAnd(backward[backwardIndex + 1], itp);
+        ++backwardIndex;
+    }
+    backward.push_back(interpolateBackward(n));
+}
+
+bool DualApproximatedReachability::globalStrengthen() {
+    if (n == 0) return false;
+    TimeMachine tm(logic());
+    SMTSolver solver(logic(), SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+    solver.assertProp(ts.getInit());
+    solver.assertProp(ts.getTransition());
+    solver.assertProp(tm.sendFlaThroughTime(ts.getTransition(), 1));
+    for (std::size_t i = 2; i <= n + 1; ++i) {
+        solver.push();
+        auto j = (n - i) + 1;
+        assert(backward.size() > j);
+        solver.assertProp(tm.sendFlaThroughTime(backward[j], i));
+        auto res = solver.check();
+        if (res == SMTSolver::Answer::UNSAT) {
+            // Compute interpolation sequence and strengthen Forward
+            auto itpContext = solver.getInterpolationContext();
+            std::vector<ipartitions_t> partitions;
+            ipartitions_t mask = 3; // First two formulas
+            partitions.push_back(mask);
+            for (std::size_t idx = 1; idx < i; ++idx) {
+                auto bitIndex = idx * 2;
+                opensmt::setbit(mask, bitIndex);
+                partitions.push_back(mask);
+            }
+            if (i == n + 1) { partitions.pop_back(); }
+            vec<PTRef> itps;
+            itpContext->getPathInterpolants(itps, partitions);
+            for (int idx = 0; idx < itps.size(); ++idx) {
+                auto forwardIndex = idx + 1;
+                assert(static_cast<std::size_t>(forwardIndex) < forward.size());
+                forward[forwardIndex] = logic().mkAnd(
+                    forward[forwardIndex], TimeMachine(logic()).sendFlaThroughTime(itps[idx], -forwardIndex));
+            }
+            iterativeLocalStrengthening(i - 1);
+            return true;
+        }
+        solver.pop();
+        solver.assertProp(tm.sendFlaThroughTime(ts.getTransition(), i));
+    }
+    return false;
+}
+
+PTRef DualApproximatedReachability::interpolateForward(std::size_t forwardIndex) {
+    TimeMachine tm(logic());
+    SMTSolver solver(logic(), SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+    auto backwardIndex = n - forwardIndex;
+    assert(forwardIndex < forward.size());
+    assert(backwardIndex < backward.size());
+    solver.assertProp(forward[forwardIndex]);
+    solver.assertProp(ts.getTransition());
+    solver.assertProp(tm.sendFlaThroughTime(backward[backwardIndex], 1));
+    auto res = solver.check();
+    if (res != SMTSolver::Answer::UNSAT) { throw std::logic_error("DAR: Cannot interpolate if query is not UNSAT!"); }
+    auto itpContex = solver.getInterpolationContext();
+    ipartitions_t mask = 3; // F + Tr
+    vec<PTRef> itps;
+    itpContex->getSingleInterpolant(itps, mask);
+    assert(itps.size() == 1);
+    return itps[0];
+}
+
+PTRef DualApproximatedReachability::interpolateBackward(std::size_t backwardIndex) {
+    TimeMachine tm(logic());
+    SMTSolver solver(logic(), SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+    auto forwardIndex = n - backwardIndex;
+    assert(forwardIndex < forward.size());
+    assert(backwardIndex < backward.size());
+    solver.assertProp(forward[forwardIndex]);
+    solver.assertProp(ts.getTransition());
+    solver.assertProp(tm.sendFlaThroughTime(backward[backwardIndex], 1));
+    auto res = solver.check();
+    if (res != SMTSolver::Answer::UNSAT) { throw std::logic_error("DAR: Cannot interpolate if query is not UNSAT!"); }
+    auto itpContex = solver.getInterpolationContext();
+    ipartitions_t mask = 6; // Tr + B
+    vec<PTRef> itps;
+    itpContex->getSingleInterpolant(itps, mask);
+    assert(itps.size() == 1);
+    return itps[0];
+}
+
+SMTSolver::Answer DualApproximatedReachability::checkSat(PTRef fla) const {
+    SMTSolver solver(logic(), SMTSolver::WitnessProduction::NONE);
+    solver.assertProp(fla);
+    return solver.check();
+}
+
+std::optional<PTRef> DualApproximatedReachability::fixpoint() const {
+    auto checkSequence = [&](Sequence const & seq) -> std::optional<std::size_t> {
+        for (std::size_t i = 1; i < seq.size(); ++i) {
+            auto candidate = seq[i];
+            vec<PTRef> previous;
+            for (std::size_t j = 0; j < i; ++j) {
+                previous.push(seq[j]);
+            }
+            PTRef disj = logic().mkOr(std::move(previous));
+            auto res = checkSat(logic().mkAnd(candidate, logic().mkNot(disj)));
+            if (res == SMTSolver::Answer::UNSAT) { return i; }
+        }
+        return std::nullopt;
+    };
+    auto maybeForwardFixpointIndex = checkSequence(forward);
+    if (maybeForwardFixpointIndex) {
+        vec<PTRef> previous;
+        for (std::size_t j = 0; j < maybeForwardFixpointIndex.value(); ++j) {
+            previous.push(forward[j]);
+        }
+        PTRef disj = logic().mkOr(std::move(previous));
+        // std::cout << "Invariant from forward sequence " << logic().pp(disj) << std::endl;
+        return disj;
+    }
+    auto maybeBackwardFixpointIndex = checkSequence(backward);
+    if (maybeBackwardFixpointIndex) {
+        vec<PTRef> previous;
+        for (std::size_t j = 0; j < maybeBackwardFixpointIndex.value(); ++j) {
+            previous.push(backward[j]);
+        }
+        PTRef disj = logic().mkOr(std::move(previous));
+        // std::cout << "Invariant from bacward sequence " << logic().pp(logic().mkNot(disj)) << std::endl;
+        return logic().mkNot(disj);
+    }
+    return std::nullopt;
+}
+
+[[maybe_unused]] void DualApproximatedReachability::showSequences() const {
+    std::cout << "Forward sequence has " << forward.size() << " elements\n";
+    for (PTRef el : forward) {
+        std::cout << logic().pp(el) << '\n';
+    }
+    std::cout << '\n';
+    std::cout << "Backward sequence has " << backward.size() << " elements\n";
+    for (PTRef el : backward) {
+        std::cout << logic().pp(el) << '\n';
+    }
+}

--- a/src/engine/DAR.h
+++ b/src/engine/DAR.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "Engine.h"
+
+#ifndef DAR_H
+#define DAR_H
+
+class DAR : public Engine {
+    Logic & logic;
+    bool computeWitness = false;
+
+public:
+    DAR(Logic & logic, Options const & options) : logic(logic) {
+        computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
+    }
+
+    VerificationResult solve(ChcDirectedHyperGraph const & graph) override {
+        if (graph.isNormalGraph()) {
+            auto normalGraph = graph.toNormalGraph();
+            return solve(*normalGraph);
+        }
+        return VerificationResult(VerificationAnswer::UNKNOWN);
+    }
+
+    VerificationResult solve(ChcDirectedGraph const & graph);
+
+private:
+    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
+    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
+};
+
+#endif // DAR_H

--- a/src/engine/EngineFactory.cc
+++ b/src/engine/EngineFactory.cc
@@ -8,6 +8,7 @@
 
 #include "ArgBasedEngine.h"
 #include "Bmc.h"
+#include "DAR.h"
 #include "IMC.h"
 #include "Kind.h"
 #include "Lawi.h"
@@ -24,6 +25,8 @@ std::unique_ptr<Engine> EngineFactory::getEngine(std::string_view engine) && {
         return std::make_unique<TPAEngine>(logic, options, TPACore::SPLIT);
     } else if (engine == "bmc") {
         return std::make_unique<BMC>(logic, options);
+    } else if (engine == "dar") {
+        return std::make_unique<DAR>(logic, options);
     } else if (engine == "lawi") {
         return std::make_unique<Lawi>(logic, options);
     } else if (engine == "kind") {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(GolemTest)
 
 target_sources(GolemTest
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_BMC.cc"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_DAR.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_KIND.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_LAWI.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_MBP.cc"

--- a/test/test_DAR.cc
+++ b/test/test_DAR.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "TestTemplate.h"
+#include "Validator.h"
+#include "engine/DAR.h"
+#include "graph/ChcGraphBuilder.h"
+#include <gtest/gtest.h>
+
+class DARTest : public LIAEngineTest {
+};
+
+TEST_F(DARTest, test_DAR_simple_safe)
+{
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}},
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+        }};
+    DAR engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
+}
+
+TEST_F(DARTest, test_DAR_simple_unsafe)
+{
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1",{intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{{
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}},
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGt(x, two)}, {UninterpretedPredicate{current}}}
+        }};
+    DAR engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
+}


### PR DESCRIPTION
The implementation follows the description in the TACAS 2013 paper
[Intertwined Forward-Backward Reachability Analysis Using Interpolants](https://link.springer.com/chapter/10.1007/978-3-642-36742-7_22).


Initial experiments suggest reasonably good performance on LRA-TS
benchmarks from CHC-COMP.