### PR TITLE
TPA: Rewrite the DAG-handling algorithm

### DIFF
--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -117,8 +117,7 @@ public:
     VerificationAnswer solve();
 
     void resetInitialStates(PTRef);
-
-    void updateQueryStates(PTRef);
+    void resetQueryStates(PTRef);
 
     PTRef getInit() const;
     PTRef getTransitionRelation() const;


### PR DESCRIPTION
In the [FM'24 paper](https://link.springer.com/chapter/10.1007/978-3-031-71162-6_29) we came up with much nicer description of how the algorithm on DAG of transition systems works.
Here we rewrite the algorithm to match that description.
The two phases, moving along an edge from one TS to another and traversing one TS, are clearly distinguished.