### PR TITLE
Predicate Abstraction: Various improvements to improve performance

### DIFF
--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -613,6 +613,7 @@ void InterpolationTree::computeLabels(ARG const & arg) {
 
 InterpolationTree::Result InterpolationTree::solve(Logic & logic) const {
     SMTSolver solver(logic, SMTSolver::WitnessProduction::MODEL_AND_INTERPOLANTS);
+    solver.getConfig().setSimplifyInterpolant(4);
     for (auto const & node : nodes) {
         assert(node.parent == InterpolationTree::NO_ID or node.id > node.parent);
         solver.assertProp(node.label);

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -440,13 +440,14 @@ Algorithm::CEXCheckingResult Algorithm::isRealProof(UnprocessedEdge const & edge
             true, computeWitness ? std::make_optional(computeInvalidityWitness(interpolationTree, *itpResult.model))
                                  : std::nullopt);
     } else {
-        TimeMachine timeMachine(clauses.getLogic());
+        TimeMachine const timeMachine(clauses.getLogic());
         RefinementInfo refinementInfo;
         for (auto const & node : interpolationTree.getNodes()) {
             if (node.parent == InterpolationTree::NO_ID) { continue; }
             assert(itpResult.interpolant.count(node.id) > 0);
-            PTRef interpolant = itpResult.interpolant.at(node.id);
-            PTRef clearedInterpolant = timeMachine.versionedFormulaToUnversioned(interpolant);
+            PTRef const interpolant = itpResult.interpolant.at(node.id);
+            if (interpolant == clauses.getLogic().getTerm_true()) { continue; }
+            PTRef const clearedInterpolant = timeMachine.versionedFormulaToUnversioned(interpolant);
             auto symbol = clauses.getTarget(node.clauseId);
             refinementInfo[symbol].insert(clearedInterpolant);
         }

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -177,10 +177,13 @@ public:
     [[nodiscard]] std::set<PTRef> computePropagatedPredicates(C const & candidates, std::vector<NodeId> const & sources,
                                                               PTRef edgeConstraint) const;
 private:
-    /// NOTE: Currently we check exact match, or if the existing instance have no satisfied predicates.
-    /// This can be improved with proper subsumption
     static bool isCoveredByExistingInstance(CartesianPredicateAbstractionStates const & candidate, CartesianPredicateAbstractionStates const & existingInstance) {
-        return existingInstance.getPredicates().empty() or candidate == existingInstance;
+        auto const & existingPredicates = existingInstance.getPredicates();
+        if (existingPredicates.empty()) { return true; }
+        auto const & candidatePredicates = candidate.getPredicates();
+        if (candidatePredicates.size() < existingPredicates.size()) { return false; }
+        return std::includes(candidate.getPredicates().begin(), candidate.getPredicates().end(),
+                             existingPredicates.begin(), existingPredicates.end());
     }
 };
 

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -382,7 +382,6 @@ void Algorithm::computeNewUnprocessedEdges(ARG::NodeId nodeId) {
     };
 
     auto const & candidateClauses = representation.getOutgoingEdgesFor(arg.getPredicateSymbol(nodeId));
-    // TODO: We may get the same edge multiple times if the predicate symbol appears multiple times in the body
     for (EId edge : candidateClauses) {
         // find all instances of edge sources in ARG and check feasibility
         auto const & sources = clauses.getSources(edge);
@@ -395,13 +394,15 @@ void Algorithm::computeNewUnprocessedEdges(ARG::NodeId nodeId) {
         }
         std::vector<std::size_t> indices(sources.size(), 0u);
         Checker checker(clauses.getEdgeLabel(edge), clauses.getLogic(), arg);
+        std::vector<ARG::NodeId> argSources;
+        argSources.reserve(sources.size());
         for (; indices[0] != allInstances[0].size(); increment(indices, allInstances)) {
-            std::vector<ARG::NodeId> argSources;
+            argSources.clear();
             for (std::size_t i = 0; i < indices.size(); ++i) {
                 argSources.push_back(allInstances[i][indices[i]]);
             }
             if (std::find(argSources.begin(), argSources.end(), nodeId) == argSources.end()) { continue; }
-            if (std::any_of(argSources.begin(), argSources.end(), [&](auto nodeId) { return arg.isCovered(nodeId); })) {
+            if (std::any_of(argSources.begin(), argSources.end(), [this](auto sourceId) { return arg.isCovered(sourceId); })) {
                 continue;
             }
             UnprocessedEdge newEdge{.eid = edge, .sources = std::move(argSources)};

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -130,8 +130,9 @@ public:
         ARGNode node{symbol,
                      std::make_unique<CartesianPredicateAbstractionStates>(predicateManager, std::move(predicates))};
         auto & existingInstances = instances.at(symbol);
-        auto const it = std::find_if(existingInstances.begin(), existingInstances.end(),
-                               [&](NodeId id) { return isCoveredByExistingInstance(*node.reachedStates, *nodes[id].reachedStates); });
+        auto const it = std::find_if(existingInstances.begin(), existingInstances.end(), [&](NodeId id) {
+            return isCoveredByExistingInstance(*node.reachedStates, *nodes[id].reachedStates);
+        });
         bool covered = it != existingInstances.end();
         auto id = nodes.size();
         nodes.push_back(std::move(node));
@@ -176,8 +177,10 @@ public:
     template<typename C>
     [[nodiscard]] std::set<PTRef> computePropagatedPredicates(C const & candidates, std::vector<NodeId> const & sources,
                                                               PTRef edgeConstraint) const;
+
 private:
-    static bool isCoveredByExistingInstance(CartesianPredicateAbstractionStates const & candidate, CartesianPredicateAbstractionStates const & existingInstance) {
+    static bool isCoveredByExistingInstance(CartesianPredicateAbstractionStates const & candidate,
+                                            CartesianPredicateAbstractionStates const & existingInstance) {
         auto const & existingPredicates = existingInstance.getPredicates();
         if (existingPredicates.empty()) { return true; }
         auto const & candidatePredicates = candidate.getPredicates();
@@ -763,9 +766,8 @@ void ARG::refine(RefinementInfo const & refinementInfo) {
         if (edges.size() != 1) { throw std::logic_error{"This approach works only for single incoming edge!"}; }
         auto const & edge = edges[0];
         assert(clauses.getEdge(edge.clauseId).to == node.predicateSymbol);
-        bool sourceChanged = std::any_of(edge.sources.begin(), edge.sources.end(), [&changed](NodeId nodeId) {
-            return changed[nodeId];
-        });
+        bool sourceChanged = std::any_of(edge.sources.begin(), edge.sources.end(),
+                                         [&changed](NodeId nodeId) { return changed[nodeId]; });
         auto it = refinementInfo.find(node.predicateSymbol);
         bool hasPotentiallyNewPredicates = it != refinementInfo.end();
         if (not sourceChanged and not hasPotentiallyNewPredicates) { continue; }
@@ -773,16 +775,12 @@ void ARG::refine(RefinementInfo const & refinementInfo) {
         RefinementInfo::mapped_type candidates;
         if (hasPotentiallyNewPredicates) {
             for (PTRef candidate : it->second) {
-                if (existingPredicates.count(candidate) == 0) {
-                    candidates.insert(candidate);
-                }
+                if (existingPredicates.count(candidate) == 0) { candidates.insert(candidate); }
             }
         }
         if (sourceChanged) { // We need to recheck all existing predicates that have not held already
             for (PTRef candidate : existingPredicates) {
-                if (node.reachedStates->satisfiedPredicates.count(candidate) == 0) {
-                    candidates.insert(candidate);
-                }
+                if (node.reachedStates->satisfiedPredicates.count(candidate) == 0) { candidates.insert(candidate); }
             }
         }
         if (candidates.empty()) { continue; }


### PR DESCRIPTION
This PR includes a few improvements of the PA engine.

- Unsatisfiability proof is created as a DAG, not a tree: The proof is much more compact and in line with how other engines create it.
- Interpolants are simplified before used as predicates: Interpolants from proofs are typically very redundant. Since we use them repeatedly in further checks, it pays off to simplify them as much as possible beforehand.
- Covering relation is based on subsumption (set inclusion) instead of equality of the satisfied predicate sets.
- Refinement procedure is fixed and improved: When refining ARG after refuting spurious CEX we only check for predicates that were not satisfied before. Also, when some parent of a node has changed, we also need to re-check the child node, because some of the predicates that were not satisfied before might be satisfied now.
- New edges are checked for feasibility only just before we compute the target node. Previously they were checked immediately when a new node was created. However, some edge might become infeasible (due to refinement) while it is waiting in a queue. Checking feasibility later should prevent expanding infeasible edges.