### PR TITLE
More efficient computation of inductive invariants from k-inductive ones

### DIFF
--- a/src/TransitionSystem.h
+++ b/src/TransitionSystem.h
@@ -82,7 +82,19 @@ private:
     PTRef toNextStateVar(PTRef var) const;
 };
 
-PTRef kinductiveToInductive(PTRef invariant, unsigned long k, TransitionSystem const & system);
+struct KTo1Inductive {
+    enum class Mode { UNFOLD, LEGACY };
+    explicit KTo1Inductive(Mode mode) : mode(mode) {}
+    [[nodiscard]] PTRef kinductiveToInductive(PTRef invariant, unsigned k, TransitionSystem const & system) const;
+private:
+    Mode mode;
+
+    [[nodiscard]] static PTRef legacy(PTRef invariant, unsigned k, TransitionSystem const & system);
+    [[nodiscard]] static PTRef unfold(PTRef invariant, unsigned k, TransitionSystem const & system);
+
+};
+
+PTRef kinductiveToInductive(PTRef invariant, unsigned k, TransitionSystem const & system);
 
 
 


### PR DESCRIPTION
The computation only needs interpolation, not quantifier elimination, it is based on the analysis of reinforced unfold transformation from the 2015 paper [Horn Clause Solvers for Program Verification](https://link.springer.com/chapter/10.1007/978-3-319-23534-9_2).