### PR TITLE
Witnesses: Simplify ValidityWitness

### DIFF
--- a/src/Validator.h
+++ b/src/Validator.h
@@ -12,22 +12,24 @@
 #include "graph/ChcGraph.h"
 
 struct ValidationException : public std::runtime_error {
-public:
-    ValidationException(const std::string & msg) : std::runtime_error(msg) {}
-    ValidationException(const char * msg) : std::runtime_error(msg) {}
+    explicit ValidationException(const std::string & msg) : std::runtime_error(msg) {}
+    explicit ValidationException(const char * msg) : std::runtime_error(msg) {}
 };
 
 class Validator {
     Logic & logic;
 public:
-    Validator(Logic & logic) : logic(logic) {}
+    explicit Validator(Logic & logic) : logic(logic) {}
 
     enum class Result {VALIDATED, NOT_VALIDATED};
     Result validate(ChcDirectedHyperGraph const & system, VerificationResult const & result);
 
 private:
-    Result validateValidityWitness(ChcDirectedHyperGraph const & graph, ValidityWitness const & witness);
-    Result validateInvalidityWitness(ChcDirectedHyperGraph const & graph, InvalidityWitness const & witness);
+    [[nodiscard]]
+    Result validateValidityWitness(ChcDirectedHyperGraph const & graph, ValidityWitness const & witness) const;
+
+    [[nodiscard]]
+    Result validateInvalidityWitness(ChcDirectedHyperGraph const & graph, InvalidityWitness const & witness) const;
 };
 
 

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -84,7 +84,7 @@ public:
 };
 
 class ValidityWitness {
-    std::unordered_map<PTRef, PTRef, PTRefHash> interpretations;
+    std::unordered_map<SymRef, PTRef, SymRefHash> interpretations;
 public:
     using definitions_t = decltype(interpretations);
 
@@ -100,9 +100,9 @@ public:
         }
     }
 
-    definitions_t getDefinitions() const { return interpretations; }
+    [[nodiscard]] definitions_t const & getDefinitions() const { return interpretations; }
 
-    void print(std::ostream & out, Logic & logic) const;
+    void print(std::ostream & out, ChcDirectedHyperGraph const & graph) const;
 
     static ValidityWitness fromTransitionSystem(Logic & logic, ChcDirectedGraph const & graph,
                                                 TransitionSystem const & transitionSystem, PTRef invariant);

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -380,11 +380,11 @@ VerificationResult Algorithm::run() {
     Logic & logic = clauses.getLogic();
     for (SymRef symbol : clauses.getVertices()) {
         if (symbol == logic.getSym_true()) {
-            definitions.emplace(logic.getTerm_true(), logic.getTerm_true());
+            definitions.emplace(symbol, logic.getTerm_true());
             continue;
         }
         if (symbol == logic.getSym_false()) {
-            definitions.emplace(logic.getTerm_false(), logic.getTerm_false());
+            definitions.emplace(symbol, logic.getTerm_false());
             continue;
         }
         auto const & argNodeIds = arg.getInstancesFor(symbol);
@@ -393,11 +393,7 @@ VerificationResult Algorithm::run() {
             reachedStates.push(arg.getReachedStates(nodeId));
         }
         PTRef definition = logic.mkOr(std::move(reachedStates));
-        PTRef sourcePredicate = clauses.getStateVersion(symbol);
-        PTRef predicate = logic.getPterm(sourcePredicate).size() > 0
-                              ? VersionManager(logic).sourceFormulaToBase(sourcePredicate)
-                              : sourcePredicate;
-        definitions.emplace(predicate, definition);
+        definitions.emplace(symbol, definition);
     }
     return VerificationResult{VerificationAnswer::SAFE, ValidityWitness(std::move(definitions))};
 }

--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -1596,8 +1596,7 @@ witness_t TransitionSystemNetworkManager::computeValidityWitness() const {
         assert(res == ReachabilityResult::UNREACHABLE);
         if (res == ReachabilityResult::UNREACHABLE) {
             PTRef graphInvariant = utils.varSubstitute(node.solver->getInductiveInvariant(), subs);
-            PTRef unversionedPredicate = logic.mkUninterpFun(vertex, std::move(unversionedVars));
-            definitions[unversionedPredicate] = graphInvariant;
+            definitions[vertex] = graphInvariant;
         } else {
             return NoWitness("Unexpected situation occurred during witness computation in TPA engine");
         }

--- a/src/transformers/NestedLoopTransformation.cc
+++ b/src/transformers/NestedLoopTransformation.cc
@@ -132,17 +132,11 @@ NestedLoopTransformation::WitnessBackTranslator::translateInvariant(ValidityWitn
         vertexInvariants.insert(inv);
     }
     for (auto v : loopContractionInfos) {
-        PTRef unversionedPredicate =
-            TimeMachine(logic).versionedFormulaToUnversioned(graph.getStateVersion(v.loopVertex));
-        PTRef mergedInv = wtns.getDefinitions().at(unversionedPredicate);
+        PTRef mergedInv = wtns.getDefinitions().at(v.loopVertex);
         for (auto vertex : oldVertices) {
             if (vertex == initialGraph.getEntry() or vertex == initialGraph.getExit()) { continue; }
-            PTRef locationVar;
-            if (v.locations.find(vertex) != v.locations.end()) {
-                locationVar = timeMachine.getUnversioned(v.locations.at(vertex));
-            } else {
-                continue;
-            }
+            if (v.locations.find(vertex) == v.locations.end()) { continue; }
+            PTRef locationVar = timeMachine.getUnversioned(v.locations.at(vertex));
             substitutions.at(locationVar) = logic.getTerm_true();
             auto vertexInvariant = utils.varSubstitute(mergedInv, substitutions);
             substitutions.at(locationVar) = logic.getTerm_false();
@@ -191,10 +185,10 @@ NestedLoopTransformation::WitnessBackTranslator::translateInvariant(ValidityWitn
                 varSubstitutions.insert({timeMachine.getUnversioned(positionVar), logic.getPterm(basePredicate)[i]});
             }
             vertexInvariant = utils.varSubstitute(vertexInvariant, varSubstitutions);
-            if (vertexInvariants.find(basePredicate) != vertexInvariants.end()) {
-                vertexInvariants[basePredicate] = vertexInvariant;
+            if (vertexInvariants.find(vertex) != vertexInvariants.end()) {
+                vertexInvariants[vertex] = vertexInvariant;
             } else {
-                vertexInvariants.insert({basePredicate, vertexInvariant});
+                vertexInvariants.insert({vertex, vertexInvariant});
             }
             // std::cout << logic.printSym(vertex) << " -> " << logic.pp(vertexInvariant) << std::endl;
         }

--- a/src/transformers/NodeEliminator.cc
+++ b/src/transformers/NodeEliminator.cc
@@ -129,9 +129,7 @@ ValidityWitness NodeEliminator::BackTranslator::translate(ValidityWitness witnes
     auto definitionFor = [&](SymRef vertex) {
         if (vertex == logic.getSym_false()) { return logic.getTerm_false(); }
         if (vertex == logic.getSym_true()) { return logic.getTerm_true(); }
-        auto it = std::find_if(definitions.begin(), definitions.end(), [&](auto const & entry){
-            return logic.getSymRef(entry.first) == vertex;
-        });
+        auto it = definitions.find(vertex);
         return it != definitions.end() ? it->second : PTRef_Undef;
     };
     VersionManager manager(logic);
@@ -189,11 +187,8 @@ ValidityWitness NodeEliminator::BackTranslator::translate(ValidityWitness witnes
         ipartitions_t Amask = 1;
         itpContext->getSingleInterpolant(itps, Amask);
         PTRef vertexSolution = manager.targetFormulaToBase(itps[0]);
-        PTRef predicateSourceRepresentation = predicateRepresentation.getSourceTermFor(vertex);
-        // TODO: Fix handling of 0-ary predicates
-        PTRef predicate = logic.isVar(predicateSourceRepresentation) ? predicateSourceRepresentation : manager.sourceFormulaToBase(predicateSourceRepresentation);
-        assert(definitions.count(predicate) == 0);
-        definitions.insert({predicate, vertexSolution});
+        assert(definitions.count(vertex) == 0);
+        definitions.insert({vertex, vertexSolution});
     }
     return ValidityWitness(std::move(definitions));
 }

--- a/src/transformers/RemoveUnreachableNodes.h
+++ b/src/transformers/RemoveUnreachableNodes.h
@@ -15,13 +15,11 @@ public:
 
     class BackTranslator : public WitnessBackTranslator {
         Logic & logic;
-        NonlinearCanonicalPredicateRepresentation predicateRepresentation;
         std::vector<SymRef> removedNodes;
 
     public:
-        BackTranslator(Logic & logic, NonlinearCanonicalPredicateRepresentation predicateRepresentation, std::vector<SymRef> && removedNodes) :
+        BackTranslator(Logic & logic, std::vector<SymRef> && removedNodes) :
             logic(logic),
-            predicateRepresentation(std::move(predicateRepresentation)),
             removedNodes(std::move(removedNodes))
             {}
 

--- a/src/transformers/SingleLoopTransformation.cc
+++ b/src/transformers/SingleLoopTransformation.cc
@@ -201,7 +201,7 @@ SingleLoopTransformation::WitnessBackTranslator::translateInvariant(PTRef induct
             varSubstitutions.insert({positionVar, logic.getPterm(basePredicate)[i]});
         }
         vertexInvariant = utils.varSubstitute(vertexInvariant, varSubstitutions);
-        vertexInvariants.insert({basePredicate, vertexInvariant});
+        vertexInvariants.insert({vertex, vertexInvariant});
         // std::cout << logic.printSym(vertex) << " -> " << logic.pp(vertexInvariant) << std::endl;
     }
     return ValidityWitness(std::move(vertexInvariants));

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -82,7 +82,9 @@ TEST_F(Transformer_test, test_SingleChain_NoLoop) {
     auto hyperGraph = systemToGraph(system);
     auto originalGraph = *hyperGraph;
     auto [summarizedGraph, translator] = SimpleChainSummarizer().transform(std::move(hyperGraph));
-    ValidityWitness witness{};
+    ValidityWitness witness{
+        {{summarizedGraph->getEntry(), logic.getTerm_true()}, {summarizedGraph->getExit(), logic.getTerm_false()}}
+    };
     auto translatedWitness = translator->translate(witness);
     Validator validator(logic);
     VerificationResult result(VerificationAnswer::SAFE, translatedWitness);
@@ -123,7 +125,12 @@ TEST_F(Transformer_test, test_TwoChains_WithLoop) {
     VersionManager manager{logic};
     PTRef predicate = manager.sourceFormulaToBase(newGraph->getStateVersion(s2));
     PTRef var = logic.getPterm(predicate)[0];
-    ValidityWitness witness{{{predicate, logic.mkGeq(var,zero)}}};
+    ValidityWitness witness{
+        {
+            {newGraph->getEntry(), logic.getTerm_true()}, {s2, logic.mkGeq(var, zero)},
+            {newGraph->getExit(), logic.getTerm_false()}
+        }
+    };
     auto translatedWitness = translator->translate(witness);
     Validator validator(logic);
     VerificationResult result(VerificationAnswer::SAFE, translatedWitness);


### PR DESCRIPTION
Instead of remembering the unversioned form of the predicate, with the variables, it is sufficient in most cases to use just the symbol and compute the variables from the associated graph on demand.