### PR TITLE
Graph: Fix computation of auxiliary variables in edge's label

### DIFF
--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -516,8 +516,7 @@ ChcDirectedHyperGraph::VertexContractionResult ChcDirectedHyperGraph::contractVe
         for (std::size_t outgoingIndex = 0; outgoingIndex < outgoingEdges.size(); ++outgoingIndex) {
             EId outgoingId = outgoingEdges[outgoingIndex];
             if (getSources(outgoingId).size() > 1 and incomingEdges.size() > 1) { throw std::logic_error("Unable to contract vertex with outgoing hyperedge!"); }
-            bool requiresRenamingAuxiliaryVars =  incomingSource == getEntry() and outgoingEdges.size() > 1
-                                                 and getSources(outgoingId).size() > 1;
+            bool requiresRenamingAuxiliaryVars = incomingSource == getEntry() and getSources(outgoingId).size() > 1;
             auto replacingEdge = mergeEdgePair(incomingId, outgoingId, requiresRenamingAuxiliaryVars);
             result.replacing.emplace_back(std::move(replacingEdge), std::make_pair(incomingIndex, outgoingIndex));
         }


### PR DESCRIPTION
Previously, we detected auxiliary variables in an edge's label simply by checking the names of the variables.
However, this is not reliable, because preprocessing passes can create new edges where previously state variables are now auxiliary. Since we do not rename such variables at the moment, we need more precise check if a variable is auxiliary or not.

Additionally, we need to rename auxiliary variables in more cases than previously thought.

Fixes #99.