### PR TITLE
NodeEliminator: Rename auxiliary variables preemptively

### DIFF
--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -308,8 +308,7 @@ PTRef renameAuxiliaries(ChcDirectedHyperGraph const & graph, EId incoming) {
     TermUtils::substitutions_map substitutionsMap;
     TimeMachine tm(logic);
     for (PTRef var : incomingAuxVars) {
-        std::string newName = tm.getUnversionedName(var);
-        newName += "#" + std::to_string(counter++);
+        std::string newName = "gaux#" + std::to_string(counter++);
         PTRef newVar = tm.getVarVersionZero(newName, logic.getSortRef(var));
         substitutionsMap.insert({var, newVar});
     }

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -344,7 +344,7 @@ private:
         }
     }
 
-    DirectedHyperEdge mergeEdgePair(EId first, EId second, bool requiresRenamingAuxiliaryVars = false);
+    DirectedHyperEdge mergeEdgePair(EId first, EId second);
     DirectedHyperEdge mergeEdges(std::vector<EId> const & chain);
     PTRef mergeLabels(std::vector<EId> const & chain) const;
 };


### PR DESCRIPTION
Instead of trying to guess when variable renaming is necessary, and trying to rename variables before edge merging, a better solution is simply to rename auxialiary variables when a new edge is created (as part of edge merging).

NOTE: We could improve auxiliary variable elimination here. Currently, the elimination is only based on extracting substitutions, but it does not detect, for example, that an auxiliary variable is redundant and could be removed.

Fixes #101.