### PR TITLE
Graph: Small fixes in various utility methods

### DIFF
--- a/src/TransformationUtils.cc
+++ b/src/TransformationUtils.cc
@@ -210,14 +210,9 @@ PTRef transitionFormulaInSystemType(SystemType const & systemType, EdgeVariables
 }
 
 bool isTrivial(ChcDirectedGraph const & graph) {
-    auto vertices = graph.getVertices();
-    assert(not vertices.empty()); // NOTE: We always put Entry in the vertices, even if there are no edges
-    if (vertices.size() == 1) {
-        assert(vertices[0] == graph.getEntry());
-        return true;
-    }
-    if (vertices.size() != 2) { return false; }
-    // We have two vertices, they should be Entry and Exit
-    return (vertices[0] == graph.getEntry() or vertices[0] == graph.getExit()) and
-           (vertices[1] == graph.getEntry() or vertices[1] == graph.getExit());
+    bool onlyTrivialEdges = true;
+    graph.forEachEdge([&](DirectedEdge const & edge) {
+        onlyTrivialEdges &= (edge.from == graph.getEntry() && edge.to == graph.getExit());
+    });
+    return onlyTrivialEdges;
 }

--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -10,6 +10,7 @@
 #include "TransformationUtils.h"
 #include <iostream>
 #include <map>
+#include <set>
 
 
 namespace{
@@ -398,11 +399,14 @@ PTRef ChcDirectedHyperGraph::mergeLabels(std::vector<EId> const & chain) const {
 }
 
 std::vector<SymRef> ChcDirectedGraph::getVertices() const {
-    std::unordered_set<SymRef, SymRefHash> vertices;
+    struct Comp { bool operator()(SymRef first, SymRef second) const { return first.x < second.x; } };
+    std::set<SymRef, Comp> vertices;
     forEachEdge([&](DirectedEdge const & edge){
+        vertices.insert(edge.from);
         vertices.insert(edge.to);
     });
     vertices.insert(getEntry());
+    vertices.insert(getExit());
     return {vertices.begin(), vertices.end()};
 }
 

--- a/src/transformers/RemoveUnreachableNodes.h
+++ b/src/transformers/RemoveUnreachableNodes.h
@@ -15,12 +15,14 @@ public:
 
     class BackTranslator : public WitnessBackTranslator {
         Logic & logic;
-        std::vector<SymRef> removedNodes;
+        std::vector<SymRef> unreachableFromTrue;
+        std::vector<SymRef> backwardUnreachableFromFalse;
 
     public:
-        BackTranslator(Logic & logic, std::vector<SymRef> && removedNodes) :
+        BackTranslator(Logic & logic, std::vector<SymRef> && unreachableFromTrue, std::vector<SymRef> && backwardUnreachableFromFalse) :
             logic(logic),
-            removedNodes(std::move(removedNodes))
+            unreachableFromTrue(std::move(unreachableFromTrue)),
+            backwardUnreachableFromFalse(std::move(backwardUnreachableFromFalse))
             {}
 
         InvalidityWitness translate(InvalidityWitness witness) override { return witness; }


### PR DESCRIPTION
Fixes the check if a graph is trivial.

`RemoveUnreachableNodes` now detects the case if there is no outgoing edge from `true` (there are no facts in the system).

`ChcDirectedGraph::getVertices` now properly returns all vertices and in sorted order.

Fixes #103.