### PR TITLE
Preprocessing: First version of edge inlining 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(golem_lib
     PRIVATE graph/ChcGraphBuilder.cc
     PRIVATE transformers/CommonUtils.cc
     PRIVATE transformers/ConstraintSimplifier.cc
+    PRIVATE transformers/EdgeInliner.cc
     PRIVATE transformers/SimpleChainSummarizer.cc
     PRIVATE transformers/NodeEliminator.cc
     PRIVATE transformers/MultiEdgeMerger.cc

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -12,6 +12,8 @@
 #include "graph/ChcGraphBuilder.h"
 #include "proofs/Term.h"
 #include "transformers/ConstraintSimplifier.h"
+#include "transformers/EdgeInliner.h"
+#include "transformers/FalseClauseRemoval.h"
 #include "transformers/MultiEdgeMerger.h"
 #include "transformers/NodeEliminator.h"
 #include "transformers/RemoveUnreachableNodes.h"
@@ -486,6 +488,9 @@ void ChcInterpreterContext::interpretCheckSat() {
     transformations.push_back(std::make_unique<SimpleChainSummarizer>());
     transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
     transformations.push_back(std::make_unique<SimpleNodeEliminator>());
+    transformations.push_back(std::make_unique<EdgeInliner>());
+    transformations.push_back(std::make_unique<FalseClauseRemoval>());
+    transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
     transformations.push_back(std::make_unique<MultiEdgeMerger>());
     // TODO: Try following MultiEdgeMerger by another round of SimpleChainSummarizer and/or SimpleNodeEliminator?
     auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));

--- a/src/graph/ChcGraph.cc
+++ b/src/graph/ChcGraph.cc
@@ -482,6 +482,14 @@ ChcDirectedHyperGraph::VertexContractionResult ChcDirectedHyperGraph::contractVe
     return result;
 }
 
+DirectedHyperEdge ChcDirectedHyperGraph::inlineEdge(EId edge, EId predecessor) {
+    if (getSources(predecessor).size() > 1) { throw std::logic_error("TODO: Implement this also for hyperedge"); }
+    assert(getSources(predecessor).front() != getTarget(predecessor));
+    auto replacingEdge = mergeEdgePair(predecessor, edge);
+    deleteEdges({edge});
+    return replacingEdge;
+}
+
 ChcDirectedHyperGraph::MergedEdges ChcDirectedHyperGraph::mergeMultiEdges() {
     ChcDirectedHyperGraph::MergedEdges mergedEdges;
     std::unordered_map<std::pair<SymRef, SymRef>, std::vector<EId>, EdgeHasher> buckets;

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -358,8 +358,12 @@ private:
     }
 
     DirectedHyperEdge mergeEdgePair(EId first, EId second);
-    DirectedHyperEdge mergeEdges(std::vector<EId> const & chain);
-    PTRef mergeLabels(std::vector<EId> const & chain) const;
+
+    /** Merges a chaing of simple non-looping edges into a single edge */
+    DirectedHyperEdge mergeTrivialChain(std::vector<EId> const & chain);
+
+    /** Computes a merged label of a chain of simple non-looping edges */
+    PTRef mergeTrivialChainLabels(std::vector<EId> const & chain) const;
 };
 
 std::optional<EId> getSelfLoopFor(SymRef, ChcDirectedGraph const & graph, AdjacencyListsGraphRepresentation const & adjacencyRepresentation);

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -326,7 +326,20 @@ public:
     void deleteEdges(std::vector<EId> const & edgesToDelete);
     void deleteNode(SymRef sym);
 
+    bool isHyperEdge(EId eid) const { return getSources(eid).size() > 1; }
+    bool isSimpleLoopEdge(EId eid) const {
+        assert(not isHyperEdge(eid));
+        auto const & edge = getEdge(eid);
+        return edge.from.front() == edge.to;
+    }
+
 private:
+    PTRef createAuxiliaryVariable(SRef ref) const {
+        static long long counter = 0;
+        std::string name = "aux#g#" + std::to_string(counter++);
+        return TimeMachine(logic).getVarVersionZero(name, ref);
+    }
+
     EId newEdge(std::vector<SymRef> && from, SymRef to, InterpretedFla label) {
         EId eid = freshId();
         edges.emplace(eid, DirectedHyperEdge{.from = std::move(from), .to = to, .fla = label, .id = eid});

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -305,6 +305,8 @@ public:
     DirectedHyperEdge contractTrivialChain(std::vector<EId> const & trivialChain);
     VertexContractionResult contractVertex(SymRef sym);
 
+    DirectedHyperEdge inlineEdge(EId edge, EId predecessor);
+
     using MergedEdges = std::vector<std::pair<std::vector<DirectedHyperEdge>, DirectedHyperEdge>>;
     MergedEdges mergeMultiEdges();
 

--- a/src/transformers/EdgeInliner.cc
+++ b/src/transformers/EdgeInliner.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "EdgeInliner.h"
+
+namespace {
+using KnownValues = std::vector<PTRef>;
+using IndexMap = std::unordered_map<PTRef, unsigned, PTRefHash>;
+
+KnownValues computeKnownValues(PTRef fla, IndexMap const & varToIndex, Logic & logic) {
+    std::vector<PTRef> values(varToIndex.size(), PTRef_Undef);
+    auto conjuncts = TermUtils(logic).getTopLevelConjuncts(fla);
+    for (PTRef conjunct : conjuncts) {
+        if (logic.isEquality(conjunct)) {
+            PTRef lhs = logic.getPterm(conjunct)[0];
+            PTRef rhs = logic.getPterm(conjunct)[1];
+            if (logic.isConstant(lhs) or logic.isConstant(rhs)) {
+                PTRef var = logic.isConstant(lhs) ? rhs : lhs;
+                if (logic.isVar(var) and varToIndex.find(var) != varToIndex.end()) {
+                    values[varToIndex.at(var)] = logic.isConstant(lhs) ? lhs : rhs;
+                }
+            }
+        } else {
+            if (logic.isVar(conjunct) or (logic.isNot(conjunct) and logic.isVar(logic.getPterm(conjunct)[0]))) {
+                PTRef var = logic.isVar(conjunct) ? conjunct : logic.getPterm(conjunct)[0];
+                if (varToIndex.find(var) != varToIndex.end()) {
+                    values[varToIndex.at(var)] = logic.isVar(conjunct) ? logic.getTerm_true() : logic.getTerm_false();
+                }
+            }
+        }
+    }
+    return values;
+}
+}
+
+std::vector<EId> computeFeasibleTransitions(ChcDirectedHyperGraph const & graph, std::vector<EId> const & incomingEdges, EId outgoingEdge) {
+    std::vector<EId> feasibleTransitions;
+    if (incomingEdges.empty()) { return feasibleTransitions; }
+    auto & logic = graph.getLogic();
+    if (incomingEdges.size() == 1) {
+        if (graph.getEdgeLabel(incomingEdges.front()) != logic.getTerm_false()) {
+            feasibleTransitions.push_back(incomingEdges.front());
+        }
+        return feasibleTransitions;
+    }
+    assert(graph.getSources(outgoingEdge).size() == 1);
+    auto vertex = graph.getSources(outgoingEdge).front();
+    assert(std::all_of(incomingEdges.begin(), incomingEdges.end(), [&](EId eid){ return graph.getTarget(eid) == vertex; }));
+    TermUtils utils(logic);
+    auto sourceVars = utils.predicateArgsInOrder(graph.getStateVersion(vertex));
+    std::unordered_map<PTRef, unsigned, PTRefHash> varToIndex;
+    for (auto i = 0u; i < sourceVars.size(); ++i) {
+        varToIndex.insert({sourceVars[i], i});
+    }
+    auto sourceValues = computeKnownValues(graph.getEdgeLabel(outgoingEdge), varToIndex, logic);
+    assert(sourceValues.size() == sourceVars.size());
+    // for (auto i = 0u; i < sourceVars.size(); ++i) {
+    //     if (sourceValues[i] != PTRef_Undef) {
+    //         std::cout << logic.pp(sourceVars[i]) << " -> " << logic.pp(sourceValues[i]) << '\n';
+    //     }
+    // }
+    // std::cout << std::endl;
+
+    for (EId incomingEdge : incomingEdges) {
+        if (graph.getEdgeLabel(incomingEdge) == logic.getTerm_false()) { continue; }
+        varToIndex.clear();
+        auto targetVars = utils.predicateArgsInOrder(graph.getNextStateVersion(vertex));
+        for (auto i = 0u; i < targetVars.size(); ++i) {
+            varToIndex.insert({targetVars[i], i});
+        }
+        auto targetValues = computeKnownValues(graph.getEdgeLabel(incomingEdge), varToIndex, logic);
+        assert(targetValues.size() == sourceValues.size());
+        bool feasible = true;
+        for (auto i = 0u; i < sourceValues.size(); ++i) {
+            feasible &= sourceValues[i] == PTRef_Undef or targetValues[i] == PTRef_Undef or sourceValues[i] == targetValues[i];
+        }
+        if (feasible) { feasibleTransitions.push_back(incomingEdge); }
+        // for (auto i = 0u; i < targetValues.size(); ++i) {
+        //     if (targetValues[i] != PTRef_Undef) {
+        //         std::cout << logic.pp(targetVars[i]) << " -> " << logic.pp(targetValues[i]) << '\n';
+        //     }
+        // }
+        // std::cout << std::endl;
+        // std::cout << "Pair " << incomingEdge.id << " and " << outgoingEdge.id << " is " << (feasible ? "feasible" : "infeasible") << '\n' << '\n';
+    }
+    return feasibleTransitions;
+
+}
+
+Transformer::TransformationResult EdgeInliner::transform(std::unique_ptr<ChcDirectedHyperGraph> graph) {
+    auto adjacencyLists = AdjacencyListsGraphRepresentation::from(*graph);
+    auto edges = graph->getEdges();
+    for (auto i = 0u; i < edges.size(); ++i) {
+        auto const & edge = edges[i];
+        auto const & sources = edge.from;
+        if (sources.size() == 1 and sources.front() != graph->getEntry()) {
+            auto source = sources.front();
+            // std::cout << "Checking edge " << edge.id.id << std::endl;
+            auto const & incoming = adjacencyLists.getIncomingEdgesFor(source);
+            auto feasibleTransitions = computeFeasibleTransitions(*graph, incoming, edge.id);
+            if (feasibleTransitions.size() >= 2) { continue; }
+            if (feasibleTransitions.empty()) {
+                // This edge can never be taken
+                // std::cout << "This edge can never be taken!" << std::endl;
+                graph->deleteEdges({edge.id});
+            } else if (feasibleTransitions.size() == 1) {
+                auto predecessor = feasibleTransitions[0];
+                // TODO: See if we can remove this restriction
+                if (graph->getSources(predecessor).size() != 1 or graph->getSources(predecessor).front() == graph->getTarget(predecessor)) { continue; }
+                // Only one way how to get here, combine the two edge and remove this one
+                // std::cout << "Only one feasible input! This edge can be removed!" << std::endl;
+                // std::cout << "Inlining edge " << edge.id.id << ": " << edge.from.front().x << " -> " << edge.to.x << '\n';
+                // std::cout << "Predecessor is " << feasibleTransitions[0].id << ": " << (graph->getSources(feasibleTransitions[0]).empty() ? " " : std::to_string(graph->getSources(feasibleTransitions[0]).front().x)) << " -> " << graph->getTarget(feasibleTransitions[0]).x << '\n';
+                graph->inlineEdge(edge.id, predecessor);
+            }
+            // recompute necessary information
+            adjacencyLists = AdjacencyListsGraphRepresentation::from(*graph);
+        }
+    }
+    return std::make_pair(std::move(graph), std::make_unique<BackTranslator>());
+}

--- a/src/transformers/EdgeInliner.cc
+++ b/src/transformers/EdgeInliner.cc
@@ -7,6 +7,7 @@
 #include "EdgeInliner.h"
 
 #include "transformers/CommonUtils.h"
+#include "utils/SmtSolver.h"
 
 namespace {
 using KnownValues = std::vector<PTRef>;
@@ -109,9 +110,18 @@ Transformer::TransformationResult EdgeInliner::transform(std::unique_ptr<ChcDire
                 auto feasibleTransitions = computeFeasibleTransitions(*graph, incoming, edge.id);
                 // std::cout << "Number of feasible transitions: " << feasibleTransitions.size() << std::endl;
                 if (feasibleTransitions.size() >= 2) { continue; }
+                auto computePredecessors = [&](SymRef node) {
+                    auto const & predecessorsIds = adjacencyLists.getIncomingEdgesFor(node);
+                    std::vector<DirectedHyperEdge> predecessors;
+                    std::transform(predecessorsIds.begin(), predecessorsIds.end(), std::back_inserter(predecessors), [&](EId eid) {
+                        return graph->getEdge(eid);
+                    });
+                    return predecessors;
+                };
                 if (feasibleTransitions.empty()) {
                     // This edge can never be taken
                     // std::cout << "This edge can never be taken!" << std::endl;
+                    backtranslator->notifyEdgeDeleted(edge, computePredecessors(source));
                     graph->deleteEdges({edge.id});
                 } else if (feasibleTransitions.size() == 1) {
                     auto predecessor = feasibleTransitions[0];
@@ -120,8 +130,9 @@ Transformer::TransformationResult EdgeInliner::transform(std::unique_ptr<ChcDire
                     // std::cout << "Only one feasible input! This edge can be removed!" << std::endl;
                     // std::cout << "Inlining edge " << edge.id.id << ": " << edge.from.front().x << " -> " << edge.to.x << '\n';
                     // std::cout << "Predecessor is " << feasibleTransitions[0].id << ": " << (graph->getSources(feasibleTransitions[0]).empty() ? " " : std::to_string(graph->getSources(feasibleTransitions[0]).front().x)) << " -> " << graph->getTarget(feasibleTransitions[0]).x << '\n';
+                    auto predecessors = computePredecessors(source);
                     auto newEdge = graph->inlineEdge(edge.id, predecessor);
-                    backtranslator->replacementInfo.emplace_back(std::move(newEdge), std::make_pair(graph->getEdge(predecessor), edge));
+                    backtranslator->notifyEdgeReplaced(newEdge, edge, graph->getEdge(predecessor), std::move(predecessors));
                 }
                 somethingChanged = true;
                 // recompute necessary information
@@ -133,17 +144,22 @@ Transformer::TransformationResult EdgeInliner::transform(std::unique_ptr<ChcDire
 }
 
 InvalidityWitness EdgeInliner::BackTranslator::translate(InvalidityWitness witness) {
-    for (auto rit = replacementInfo.rbegin(); rit != replacementInfo.rend(); ++rit) {
+    for (auto rit = entries.rbegin(); rit != entries.rend(); ++rit) {
         auto const & entry = *rit;
+        if (std::holds_alternative<Deletion>(entry)) { continue; }
+        auto const & replacementInfo = std::get<Replacement>(entry);
         bool replacementUsed = true;
         while(replacementUsed) {
             replacementUsed = false;
             auto & derivation = witness.getDerivation();
             for (auto it = derivation.begin(); it != derivation.end(); ++it) {
-                if (it->clauseId == entry.first.id) {
-                    assert(entry.second.second.from.size() == 1);
+                if (it->clauseId == replacementInfo.addedEdge.id) {
+                    assert(replacementInfo.removedEdge.from.size() == 1);
                     std::size_t index = it - derivation.begin();
-                    auto newDerivation = replaceSummarizingStep(derivation, index, {entry.second.first, entry.second.second}, entry.first, predicateRepresentation, logic);
+                    auto newDerivation = replaceSummarizingStep(
+                        derivation, index, {replacementInfo.predecessor, replacementInfo.removedEdge},
+                        replacementInfo.addedEdge, predicateRepresentation, logic
+                    );
                     witness.setDerivation(std::move(newDerivation));
                     replacementUsed = true;
                     break;
@@ -152,5 +168,143 @@ InvalidityWitness EdgeInliner::BackTranslator::translate(InvalidityWitness witne
         }
     }
     return witness;
+}
+
+#define SANITY_CHECK(cond) if (not (cond)) { assert(false); return ValidityWitness{}; }
+ValidityWitness EdgeInliner::BackTranslator::translate(ValidityWitness witness) {
+    if (entries.empty()) { return witness; }
+    auto definitions = witness.getDefinitions();
+    VersionManager manager(logic);
+    for (auto rit = entries.rbegin(); rit != entries.rend(); ++rit) {
+        auto const & entry = *rit;
+        if (std::holds_alternative<Deletion>(entry)) {
+            auto const & deletedEdge = std::get<Deletion>(entry).deletedEdge;
+            SANITY_CHECK(deletedEdge.from.size() == 1);
+            auto source = deletedEdge.from.front();
+            auto target = deletedEdge.to;
+            SANITY_CHECK(predecessors.count(deletedEdge.id) > 0);
+            if (definitions.find(source) == definitions.end()) {
+                definitions.insert({source, logic.getTerm_true()});
+            }
+            // Compute an interpolant between the predecessors and the edge, conjoin to existing interpretation
+            if (predecessors.at(deletedEdge.id).empty()) {
+                definitions.at(source) = logic.getTerm_false();
+            } else if (definitions.at(source) != logic.getTerm_false()) {
+                vec<PTRef> incoming;
+                for (auto const & predecessor : predecessors.at(deletedEdge.id)) {
+                    incoming.push(predecessor.fla.fla);
+                }
+                PTRef incomingConstraint = logic.mkOr(std::move(incoming));
+                PTRef outgoingConstraint = deletedEdge.fla.fla;
+                PTRef interpolant = computeInterpolantFor(source, incomingConstraint, outgoingConstraint);
+                PTRef & currentInterpretation = definitions.at(source);
+                currentInterpretation = logic.mkAnd(currentInterpretation, interpolant);
+            }
+            if (definitions.find(target) == definitions.end()) {
+                definitions.insert({target, logic.getTerm_true()});
+            }
+            continue;
+        }
+        assert(std::holds_alternative<Replacement>(entry));
+        auto const & replacementInfo = std::get<Replacement>(entry);
+        SANITY_CHECK(replacementInfo.predecessor.from.size() == 1 and replacementInfo.removedEdge.from.size() == 1);
+        SymRef source = replacementInfo.predecessor.from.front();
+        SymRef mid = replacementInfo.predecessor.to;
+        SymRef target = replacementInfo.removedEdge.to;
+        SANITY_CHECK(definitions.find(source) != definitions.end());
+        SANITY_CHECK(definitions.find(mid) != definitions.end());
+        SANITY_CHECK(definitions.find(target) != definitions.end());
+        SANITY_CHECK(replacementInfo.predecessor.from.front() != replacementInfo.predecessor.to); // not a loop
+        SANITY_CHECK(replacementInfo.removedEdge.from.size() == 1);
+        // Compute an interpolant for mid between all predecessors and the removed edge
+        SANITY_CHECK(predecessors.count(replacementInfo.removedEdge.id) > 0);
+        vec<PTRef> incoming;
+        for (auto const & predecessor : predecessors.at(replacementInfo.removedEdge.id)) {
+            if (predecessor.id == replacementInfo.predecessor.id) {
+                PTRef sourceInterpretation = manager.baseFormulaToSource(definitions.at(source));
+                incoming.push(logic.mkAnd(sourceInterpretation, replacementInfo.predecessor.fla.fla));
+            } else {
+                incoming.push(predecessor.fla.fla);
+            }
+        }
+        PTRef incomingConstraint = logic.mkOr(std::move(incoming));
+        PTRef outgoingConstraint = logic.mkAnd(replacementInfo.removedEdge.fla.fla, logic.mkNot(manager.baseFormulaToTarget(definitions.at(target))));
+        PTRef interpolant = computeInterpolantFor(mid, incomingConstraint, outgoingConstraint);
+        PTRef & existingInterpretation = definitions.at(mid);
+        existingInterpretation = logic.mkAnd(existingInterpretation, interpolant);
+    }
+    return ValidityWitness(std::move(definitions));
+}
+
+void EdgeInliner::BackTranslator::notifyEdgeDeleted(DirectedHyperEdge const & deletedEdge, Predecessors predecessors) {
+    entries.emplace_back(Deletion{deletedEdge});
+    assert(this->predecessors.find(deletedEdge.id) == this->predecessors.end());
+    this->predecessors.insert({deletedEdge.id, std::move(predecessors)});
+}
+
+void EdgeInliner::BackTranslator::notifyEdgeReplaced(DirectedHyperEdge const & newEdge,
+                                                     DirectedHyperEdge const & removedEdge,
+                                                     DirectedHyperEdge const & predecessor,
+                                                     Predecessors predecessors) {
+    entries.emplace_back(Replacement{.addedEdge = newEdge, .removedEdge = removedEdge, .predecessor = predecessor});
+    assert(this->predecessors.find(removedEdge.id) == this->predecessors.end());
+    this->predecessors.insert({removedEdge.id, std::move(predecessors)});
+}
+
+std::vector<PTRef> EdgeInliner::BackTranslator::getAuxiliaryVarsFor(SymRef node) {
+    PTRef sourceTerm = predicateRepresentation.getSourceTermFor(node);
+    auto vars = TermUtils(logic).predicateArgsInOrder(sourceTerm);
+    for (auto i = 0u; i < vars.size(); ++i) {
+        PTRef & var = vars[i];
+        auto sort = logic.getSortRef(var);
+        std::string name = "$ei" + std::to_string(i);
+        var = logic.mkVar(sort, name.c_str());
+    }
+    return vars;
+}
+
+PTRef EdgeInliner::BackTranslator::computeInterpolantFor(SymRef node, PTRef incoming, PTRef outgoing) {
+    TermUtils utils(logic);
+    SMTSolver solver(logic, SMTSolver::WitnessProduction::ONLY_INTERPOLANTS);
+    solver.getConfig().setSimplifyInterpolant(4);
+    TermUtils::substitutions_map substitutionsMap;
+    auto auxiliaryVars = getAuxiliaryVarsFor(node);
+    auto targetVars = utils.predicateArgsInOrder(predicateRepresentation.getTargetTermFor(node));
+    assert(targetVars.size() == auxiliaryVars.size());
+    for (auto i = 0u; i < targetVars.size(); ++i) {
+        substitutionsMap.insert({targetVars[i], auxiliaryVars[i]});
+    }
+    PTRef incomingConstraintRenamed = utils.varSubstitute(incoming, substitutionsMap);
+    // A part
+    solver.assertProp(incomingConstraintRenamed);
+
+    substitutionsMap.clear();
+    auto sourceVars = utils.predicateArgsInOrder(predicateRepresentation.getSourceTermFor(node));
+    assert(sourceVars.size() == auxiliaryVars.size());
+    for (auto i = 0u; i < sourceVars.size(); ++i) {
+        substitutionsMap.insert({sourceVars[i], auxiliaryVars[i]});
+    }
+    // B part
+    PTRef outgoingConstraintRenamed = utils.varSubstitute(outgoing, substitutionsMap);
+    solver.assertProp(outgoingConstraintRenamed);
+    auto res = solver.check();
+    if (res != SMTSolver::Answer::UNSAT) {
+        std::cout << logic.pp(incomingConstraintRenamed) << '\n';
+        std::cout << '\n' << logic.pp(outgoingConstraintRenamed) << '\n';
+        throw std::logic_error("Error in backtranslating of edge inliner");
+    }
+    auto itpContext = solver.getInterpolationContext();
+    vec<PTRef> itps;
+    ipartitions_t Amask = 1;
+    itpContext->getSingleInterpolant(itps, Amask);
+    PTRef interpolant = itps[0];
+    substitutionsMap.clear();
+    auto const & baseVars = predicateRepresentation.getRepresentation(node);
+    assert(baseVars.size() == auxiliaryVars.size());
+    for (auto i = 0u; i < auxiliaryVars.size(); ++i) {
+        substitutionsMap.insert({auxiliaryVars[i], baseVars[i]});
+    }
+    PTRef renamedInterpolant = utils.varSubstitute(interpolant, substitutionsMap);
+    return renamedInterpolant;
 }
 

--- a/src/transformers/EdgeInliner.h
+++ b/src/transformers/EdgeInliner.h
@@ -15,8 +15,16 @@ public:
     TransformationResult transform(std::unique_ptr<ChcDirectedHyperGraph> graph) override;
 
     class BackTranslator : public WitnessBackTranslator {
+        using ReplacementInfo = std::vector<std::pair<DirectedHyperEdge, std::pair<DirectedHyperEdge, DirectedHyperEdge>>>;
+        Logic & logic;
+        NonlinearCanonicalPredicateRepresentation predicateRepresentation;
     public:
-        InvalidityWitness translate(InvalidityWitness witness) override { return witness; }
+        ReplacementInfo replacementInfo;
+
+        BackTranslator(Logic & logic, NonlinearCanonicalPredicateRepresentation predicateRepresentation)
+        : logic(logic), predicateRepresentation(std::move(predicateRepresentation)) {}
+
+        InvalidityWitness translate(InvalidityWitness witness) override;
         ValidityWitness translate(ValidityWitness witness) override { return witness; }
     };
 };

--- a/src/transformers/EdgeInliner.h
+++ b/src/transformers/EdgeInliner.h
@@ -43,9 +43,9 @@ public:
                                 DirectedHyperEdge const & predecessor, Predecessors);
 
     private:
-        std::vector<PTRef> getAuxiliaryVarsFor(SymRef node);
+        std::vector<PTRef> getAuxiliaryVarsFor(SymRef node) const;
 
-        PTRef computeInterpolantFor(SymRef node, PTRef incoming, PTRef outgoing);
+        PTRef computeInterpolantFor(SymRef node, PTRef incoming, PTRef outgoing) const;
     };
 };
 

--- a/src/transformers/EdgeInliner.h
+++ b/src/transformers/EdgeInliner.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef EDGEINLINER_H
+#define EDGEINLINER_H
+
+#include "Transformer.h"
+
+class EdgeInliner : public Transformer {
+
+public:
+    TransformationResult transform(std::unique_ptr<ChcDirectedHyperGraph> graph) override;
+
+    class BackTranslator : public WitnessBackTranslator {
+    public:
+        InvalidityWitness translate(InvalidityWitness witness) override { return witness; }
+        ValidityWitness translate(ValidityWitness witness) override { return witness; }
+    };
+};
+
+
+
+#endif //EDGEINLINER_H


### PR DESCRIPTION
Edge inlining refers to a transformation where we detect if an edge has at most one feasible predecessor.
If there is no feasible predecessor, the edge can be safely removed from the graph, without affecting reachability.
If there is a single feasible predecessor, the edge can be merged with the predecessor. We can remove the original edge but must keep the predecessor, because there might be other outgoing edges from the original edge's source.
We also do not want to inline if the predecessor is a loop. That would basically meant peeling off one iteration from the loop, and that could continue for a long time.

By feasibility we mean that the conjunction of the labels of the edge and its predecessor (after appropriate variable renaming) is satisfiable.
However, we do not check satisfiability by querying an SMT solver, instead we use light-weight check where we collect constant values of the common state variables and see if they contradict each other or not.

    