### PR TITLE
Preprocessing: More node eliminations in the default pipeline

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(golem_lib
     PRIVATE QuantifierElimination.cc
     PRIVATE graph/ChcGraph.cc
     PRIVATE graph/ChcGraphBuilder.cc
+    PRIVATE transformers/BasicTransformationPipelines.cc
     PRIVATE transformers/CommonUtils.cc
     PRIVATE transformers/ConstraintSimplifier.cc
     PRIVATE transformers/EdgeInliner.cc

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -11,14 +11,7 @@
 #include "graph/ChcGraph.h"
 #include "graph/ChcGraphBuilder.h"
 #include "proofs/Term.h"
-#include "transformers/ConstraintSimplifier.h"
-#include "transformers/EdgeInliner.h"
-#include "transformers/FalseClauseRemoval.h"
-#include "transformers/MultiEdgeMerger.h"
-#include "transformers/NodeEliminator.h"
-#include "transformers/RemoveUnreachableNodes.h"
-#include "transformers/SimpleChainSummarizer.h"
-#include "transformers/TransformationPipeline.h"
+#include "transformers/BasicTransformationPipelines.h"
 
 #include <csignal>
 #include <memory>
@@ -483,20 +476,8 @@ void ChcInterpreterContext::interpretCheckSat() {
         originalGraph = std::make_unique<ChcDirectedHyperGraph>(*hypergraph);
     }
 
-    TransformationPipeline::pipeline_t transformations;
-    transformations.push_back(std::make_unique<ConstraintSimplifier>());
-    transformations.push_back(std::make_unique<SimpleChainSummarizer>());
-    transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
-    transformations.push_back(std::make_unique<SimpleNodeEliminator>());
-    transformations.push_back(std::make_unique<EdgeInliner>());
-    transformations.push_back(std::make_unique<FalseClauseRemoval>());
-    transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
-    transformations.push_back(std::make_unique<MultiEdgeMerger>());
-    transformations.push_back(std::make_unique<SimpleChainSummarizer>());
-    transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
-    transformations.push_back(std::make_unique<SimpleNodeEliminator>());
-    transformations.push_back(std::make_unique<MultiEdgeMerger>());
-    auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));
+    auto pipeline = Transformations::defaultTransformationPipeline();
+    auto [newGraph, translator] = pipeline.transform(std::move(hypergraph));
     hypergraph = std::move(newGraph);
     // This if is needed to run the portfolio of multiple engines
     auto engineName = opts.getOrDefault(Options::ENGINE, "spacer");

--- a/src/ChcInterpreter.cc
+++ b/src/ChcInterpreter.cc
@@ -492,7 +492,10 @@ void ChcInterpreterContext::interpretCheckSat() {
     transformations.push_back(std::make_unique<FalseClauseRemoval>());
     transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
     transformations.push_back(std::make_unique<MultiEdgeMerger>());
-    // TODO: Try following MultiEdgeMerger by another round of SimpleChainSummarizer and/or SimpleNodeEliminator?
+    transformations.push_back(std::make_unique<SimpleChainSummarizer>());
+    transformations.push_back(std::make_unique<RemoveUnreachableNodes>());
+    transformations.push_back(std::make_unique<SimpleNodeEliminator>());
+    transformations.push_back(std::make_unique<MultiEdgeMerger>());
     auto [newGraph, translator] = TransformationPipeline(std::move(transformations)).transform(std::move(hypergraph));
     hypergraph = std::move(newGraph);
     // This if is needed to run the portfolio of multiple engines

--- a/src/transformers/BasicTransformationPipelines.cc
+++ b/src/transformers/BasicTransformationPipelines.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022-2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "BasicTransformationPipelines.h"
+
+#include "ConstraintSimplifier.h"
+#include "EdgeInliner.h"
+#include "FalseClauseRemoval.h"
+#include "MultiEdgeMerger.h"
+#include "NodeEliminator.h"
+#include "RemoveUnreachableNodes.h"
+#include "SimpleChainSummarizer.h"
+#include "TrivialEdgePruner.h"
+
+namespace Transformations {
+TransformationPipeline towardsTransitionSystems() {
+    TransformationPipeline::pipeline_t stages;
+    stages.push_back(std::make_unique<MultiEdgeMerger>());
+    stages.push_back(std::make_unique<NonLoopEliminator>());
+    stages.push_back(std::make_unique<FalseClauseRemoval>());
+    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
+    stages.push_back(std::make_unique<MultiEdgeMerger>());
+    stages.push_back(std::make_unique<TrivialEdgePruner>());
+    TransformationPipeline pipeline(std::move(stages));
+    return pipeline;
+}
+
+TransformationPipeline defaultTransformationPipeline() {
+    TransformationPipeline::pipeline_t stages;
+    stages.push_back(std::make_unique<ConstraintSimplifier>());
+    stages.push_back(std::make_unique<SimpleChainSummarizer>());
+    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
+    stages.push_back(std::make_unique<SimpleNodeEliminator>());
+    stages.push_back(std::make_unique<EdgeInliner>());
+    stages.push_back(std::make_unique<FalseClauseRemoval>());
+    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
+    stages.push_back(std::make_unique<MultiEdgeMerger>());
+    stages.push_back(std::make_unique<SimpleChainSummarizer>());
+    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
+    stages.push_back(std::make_unique<SimpleNodeEliminator>());
+    stages.push_back(std::make_unique<MultiEdgeMerger>());
+    return TransformationPipeline(std::move(stages));
+}
+} // namespace Transformations

--- a/src/transformers/BasicTransformationPipelines.h
+++ b/src/transformers/BasicTransformationPipelines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Martin Blicha <martin.blicha@gmail.com>
+ * Copyright (c) 2022-2025, Martin Blicha <martin.blicha@gmail.com>
  *
  * SPDX-License-Identifier: MIT
  */
@@ -7,26 +7,13 @@
 #ifndef GOLEM_BASICTRANSFORMATIONPIPELINES_H
 #define GOLEM_BASICTRANSFORMATIONPIPELINES_H
 
-#include "FalseClauseRemoval.h"
-#include "MultiEdgeMerger.h"
-#include "NodeEliminator.h"
-#include "RemoveUnreachableNodes.h"
 #include "TransformationPipeline.h"
-#include "TrivialEdgePruner.h"
 
 namespace Transformations {
 
-inline TransformationPipeline towardsTransitionSystems() {
-    TransformationPipeline::pipeline_t stages;
-    stages.push_back(std::make_unique<MultiEdgeMerger>());
-    stages.push_back(std::make_unique<NonLoopEliminator>());
-    stages.push_back(std::make_unique<FalseClauseRemoval>());
-    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
-    stages.push_back(std::make_unique<MultiEdgeMerger>());
-    stages.push_back(std::make_unique<TrivialEdgePruner>());
-    TransformationPipeline pipeline(std::move(stages));
-    return pipeline;
-}
+TransformationPipeline towardsTransitionSystems();
+
+TransformationPipeline defaultTransformationPipeline();
 
 }
 

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -16,6 +16,7 @@
 #include "transformers/BasicTransformationPipelines.h"
 #include "transformers/ConstraintSimplifier.h"
 #include "transformers/EdgeInliner.h"
+#include "transformers/FalseClauseRemoval.h"
 #include "transformers/MultiEdgeMerger.h"
 #include "transformers/NestedLoopTransformation.h"
 #include "transformers/NodeEliminator.h"


### PR DESCRIPTION
We have noticed a few times that after the default preprocessing, nodes that could be eliminated by `SimpleNodeEliminator` were still present in the graph, probably because some nodes become "simple" only after the run of `MultiEdgeMerger`.