### PR TITLE
Preprocessing: Fixing issues with chain summarizer

### DIFF
--- a/src/Validator.cc
+++ b/src/Validator.cc
@@ -23,10 +23,8 @@ Validator::Result Validator::validate(ChcDirectedHyperGraph const & graph, Verif
 
 Validator::Result Validator::validateValidityWitness(ChcDirectedHyperGraph const & graph, ValidityWitness const & witness) const {
     auto definitions = witness.getDefinitions();
-    if (definitions.find(graph.getExit()) == definitions.end()) {
-        definitions.insert({graph.getExit(), logic.getTerm_false()});
-        definitions.insert({graph.getEntry(), logic.getTerm_true()});
-    }
+    assert(definitions.find(graph.getEntry()) != definitions.end());
+    assert(definitions.find(graph.getExit()) != definitions.end());
     // get correct interpretation for each node
     auto getInterpretation = [&](SymRef symbol) -> PTRef {
         auto const it = definitions.find(symbol);

--- a/src/Witnesses.cc
+++ b/src/Witnesses.cc
@@ -189,8 +189,8 @@ ValidityWitness::fromTransitionSystem(Logic & logic, ChcDirectedGraph const & gr
     TermUtils utils(logic);
     TimeMachine timeMachine(logic);
     TermUtils::substitutions_map subs;
-    auto graphVars = utils.predicateArgsInOrder(graph.getStateVersion(vertex));
-    auto systemVars = transitionSystem.getStateVars();
+    auto const graphVars = utils.predicateArgsInOrder(graph.getStateVersion(vertex));
+    auto const systemVars = transitionSystem.getStateVars();
     vec<PTRef> unversionedVars;
     assert(graphVars.size() == systemVars.size());
     for (std::size_t i = 0; i < graphVars.size(); ++i) {
@@ -199,7 +199,8 @@ ValidityWitness::fromTransitionSystem(Logic & logic, ChcDirectedGraph const & gr
     }
     PTRef graphInvariant = utils.varSubstitute(inductiveInvariant, subs);
 //    std::cout << "Graph invariant: " << logic.printTerm(graphInvariant) << std::endl;
-    ValidityWitness::definitions_t definitions{{vertex, graphInvariant}};
+    auto definitions = trivialDefinitions(graph);
+    definitions.insert({vertex, graphInvariant});
     return ValidityWitness(std::move(definitions));
 }
 
@@ -216,3 +217,26 @@ translateTransitionSystemResult(TransitionSystemVerificationResult result, ChcDi
     assert(false);
     return VerificationResult(VerificationAnswer::UNKNOWN);
 }
+
+ValidityWitness ValidityWitness::trivialWitness(ChcDirectedGraph const & graph) {
+    return ValidityWitness{trivialDefinitions(graph)};
+}
+
+ValidityWitness ValidityWitness::trivialWitness(ChcDirectedHyperGraph const & graph) {
+    return ValidityWitness{trivialDefinitions(graph)};
+}
+
+ValidityWitness::definitions_t ValidityWitness::trivialDefinitions(ChcDirectedGraph const & graph) {
+    return definitions_t{
+        std::make_pair(graph.getEntry(), graph.getLogic().getTerm_true()),
+        std::make_pair(graph.getExit(), graph.getLogic().getTerm_false())
+    };
+}
+
+ValidityWitness::definitions_t ValidityWitness::trivialDefinitions(ChcDirectedHyperGraph const & graph) {
+    return definitions_t{
+        std::make_pair(graph.getEntry(), graph.getLogic().getTerm_true()),
+        std::make_pair(graph.getExit(), graph.getLogic().getTerm_false())
+    };
+}
+

--- a/src/Witnesses.h
+++ b/src/Witnesses.h
@@ -106,6 +106,11 @@ public:
 
     static ValidityWitness fromTransitionSystem(Logic & logic, ChcDirectedGraph const & graph,
                                                 TransitionSystem const & transitionSystem, PTRef invariant);
+
+    static definitions_t trivialDefinitions(ChcDirectedGraph const & graph);
+    static definitions_t trivialDefinitions(ChcDirectedHyperGraph const & graph);
+    static ValidityWitness trivialWitness(ChcDirectedGraph const & graph);
+    static ValidityWitness trivialWitness(ChcDirectedHyperGraph const & graph);
 };
 
 class NoWitness {

--- a/src/engine/Common.cc
+++ b/src/engine/Common.cc
@@ -31,5 +31,8 @@ VerificationResult solveTrivial(ChcDirectedGraph const & graph) {
         }
     }
     // Here we know that no edge is satisfiable
-    return VerificationResult(VerificationAnswer::SAFE, ValidityWitness{});
+    std::unordered_map<SymRef, PTRef, SymRefHash> solution;
+    solution.insert({graph.getEntry(), logic.getTerm_true()});
+    solution.insert({graph.getExit(), logic.getTerm_false()});
+    return {VerificationAnswer::SAFE, ValidityWitness{std::move(solution)}};
 }

--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -1579,7 +1579,7 @@ witness_t TransitionSystemNetworkManager::computeValidityWitness() const {
     assert(isTransitionSystemDAG(graph));
     TermUtils utils(logic);
     TimeMachine timeMachine(logic);
-    ValidityWitness::definitions_t definitions;
+    auto definitions = ValidityWitness::trivialDefinitions(graph);
 
     for (auto vertex : graph.getVertices()) {
         if (vertex == graph.getEntry() || vertex == graph.getExit()) continue;

--- a/src/transformers/NodeEliminator.cc
+++ b/src/transformers/NodeEliminator.cc
@@ -130,8 +130,6 @@ ValidityWitness NodeEliminator::BackTranslator::translate(ValidityWitness witnes
     auto definitions = witness.getDefinitions();
 
     auto definitionFor = [&](SymRef vertex) {
-        if (vertex == logic.getSym_false()) { return logic.getTerm_false(); }
-        if (vertex == logic.getSym_true()) { return logic.getTerm_true(); }
         auto it = definitions.find(vertex);
         return it != definitions.end() ? it->second : PTRef_Undef;
     };

--- a/src/transformers/SimpleChainSummarizer.cc
+++ b/src/transformers/SimpleChainSummarizer.cc
@@ -19,9 +19,9 @@ Transformer::TransformationResult SimpleChainSummarizer::transform(std::unique_p
             if (incoming.size() != 1) { return false; }
             auto const & outgoing = adjacencyList.getOutgoingEdgesFor(sym);
             if (outgoing.size() != 1) { return false; }
-            EId in = incoming[0];
-            EId out = outgoing[0];
-            return in != out and graph->getSources(in).size() == 1 and graph->getSources(out).size() == 1;
+            EId const in = incoming[0];
+            EId const out = outgoing[0];
+            return in != out and graph->getSources(in).size() == 1 and graph->getSources(out).size() == 1 and graph->getSources(in)[0] != graph->getTarget(out);
         };
         auto vertices = graph->getVertices();
         auto it = std::find_if(vertices.begin(), vertices.end(), isTrivial);

--- a/src/transformers/SimpleChainSummarizer.cc
+++ b/src/transformers/SimpleChainSummarizer.cc
@@ -35,16 +35,18 @@ Transformer::TransformationResult SimpleChainSummarizer::transform(std::unique_p
                 assert(outgoing.size() == 1);
                 edges.push_back(outgoing[0]);
                 current = graph->getTarget(outgoing[0]);
-            } while (isTrivial(current));
+            } while (isTrivial(current) and current != vertex);
+            auto last = current;
             current = vertex;
-            do {
+            while (isTrivial(current)) {
                 auto const & incoming = adjacencyList.getIncomingEdgesFor(current);
                 assert(incoming.size() == 1);
-                edges.insert(edges.begin(), incoming[0]);
                 auto const & sources = graph->getSources(incoming[0]);
                 assert(sources.size() == 1);
                 current = sources[0];
-            } while (isTrivial(current));
+                if (current == last) { break; } // This means we have come full circle; we do not add the last edge.
+                edges.insert(edges.begin(), incoming[0]);
+            }
             return edges;
         }(trivialVertex);
         std::vector<DirectedHyperEdge> summarizedChain;

--- a/src/transformers/SingleLoopTransformation.cc
+++ b/src/transformers/SingleLoopTransformation.cc
@@ -157,7 +157,7 @@ SingleLoopTransformation::WitnessBackTranslator::translateInvariant(PTRef induct
         substitutions.insert({locationVar, logic.getTerm_false()});
     }
 
-    ValidityWitness::definitions_t vertexInvariants;
+    auto vertexInvariants = ValidityWitness::trivialDefinitions(graph);
     for (auto vertex : vertices) {
         if (vertex == graph.getEntry() or vertex == graph.getExit()) { continue; }
         PTRef locationVar = this->locationVarMap.at(vertex);

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -502,7 +502,7 @@ TEST_F(Transformer_test, test_NodeEliminator_PredicateWithoutVariables) {
     SimpleNodeEliminator transformation;
     auto [transformedGraph, backtranslator] = transformation.transform(std::move(hyperGraph));
     ASSERT_EQ(transformedGraph->getEdges().size(), 1);
-    ValidityWitness witness = backtranslator->translate(ValidityWitness());
+    ValidityWitness witness = backtranslator->translate(ValidityWitness::trivialWitness(*transformedGraph));
     Validator validator(logic);
     auto res = validator.validate(originalGraph, VerificationResult(VerificationAnswer::SAFE, witness));
     ASSERT_EQ(res, Validator::Result::VALIDATED);
@@ -585,8 +585,7 @@ TEST_F(Transformer_New_Test, test_SimpleNodeEliminator_HyperEdge_Safe) {
     ASSERT_EQ(edge.to, transformedGraph->getExit());
     ASSERT_EQ(edge.from.size(), 1);
     ASSERT_EQ(edge.from.at(0), transformedGraph->getEntry());
-    ValidityWitness witness{};
-    auto translatedWitness = translator->translate(witness);
+    auto translatedWitness = translator->translate(ValidityWitness::trivialWitness(*transformedGraph));
     VerificationResult translatedResult(VerificationAnswer::SAFE, translatedWitness);
     Validator validator(logic);
     EXPECT_EQ(validator.validate(originalGraph, translatedResult), Validator::Result::VALIDATED);
@@ -680,8 +679,7 @@ TEST_F(Transformer_New_Test, test_SimpleNodeEliminator_HyperEdgeBooleanConstrain
     ASSERT_EQ(edge.to, transformedGraph->getExit());
     ASSERT_EQ(edge.from.size(), 1);
     ASSERT_EQ(edge.from.at(0), transformedGraph->getEntry());
-    ValidityWitness witness{};
-    auto translatedWitness = translator->translate(witness);
+    auto translatedWitness = translator->translate(ValidityWitness::trivialWitness(*transformedGraph));
     VerificationResult translatedResult(VerificationAnswer::SAFE, translatedWitness);
     Validator validator(logic);
     EXPECT_EQ(validator.validate(originalGraph, translatedResult), Validator::Result::VALIDATED);


### PR DESCRIPTION
Previously, chain summarizer would summarize (contract) an entire loop if it consisted of simple edges.
While this may be OK, the backtranslator does not work correctly in this case.

The solution is to not summarize the entire loop, but skip one edges, thus forming proper simple chain.
The last node can be processed by node eliminator correctly.