### PR TITLE
PDKIND: Cleanup and improvements

### DIFF
--- a/src/engine/PDKind.h
+++ b/src/engine/PDKind.h
@@ -10,110 +10,6 @@
 #include "Engine.h"
 #include "TransitionSystem.h"
 
-#include "osmt_solver.h"
-#include "osmt_terms.h"
-
-#include <memory>
-#include <set>
-#include <tuple>
-
-/**
- * Counter example formula in addition with number of steps needed to reach the counter example.
- */
-struct CounterExample {
-    PTRef ctx;
-    unsigned num_of_steps;
-    CounterExample(PTRef ctx, unsigned num_of_steps) : ctx(ctx), num_of_steps(num_of_steps) {}
-};
-
-/**
- * Tuple containing lemma and counter example.
- */
-struct IFrameElement {
-        PTRef lemma;
-        CounterExample counter_example;
-
-        IFrameElement(PTRef lemma, CounterExample counter_example) : lemma(lemma), counter_example(counter_example) {}
-
-        bool operator==(IFrameElement const & other) const {
-            return this->lemma == other.lemma && this->counter_example.ctx == other.counter_example.ctx;
-        }
-
-        bool operator<(IFrameElement const & other) const {
-            if (this->lemma == other.lemma) {
-                return this->counter_example.ctx < other.counter_example.ctx;
-            } else {
-                return this->lemma < other.lemma;
-            }
-        }
-};
-
-/**
- * Wrapper for Induction Frame set.
- */
-using InductionFrame = std::set<IFrameElement>;
-
-/**
- * Wrapper for return value of the Push function.
- */
-struct PushResult {
-    InductionFrame i_frame;
-    InductionFrame new_i_frame;
-    int n;
-    bool is_invalid;
-    int steps_to_ctx;
-    PushResult(InductionFrame i_frame,
-               InductionFrame new_i_frame,
-               int n,
-               bool is_invalid,
-               int steps_to_ctx) : i_frame(std::move(i_frame)), new_i_frame(std::move(new_i_frame)), n(n), is_invalid(is_invalid), steps_to_ctx(steps_to_ctx) {}
-};
-
-/**
- * A data structure where r[i] represents the states that are reachable in i steps from some initial states, i.e., r[0].
- */
-class RFrames {
-public:
-    explicit RFrames(Logic & logic) : logic(logic) {}
-
-    PTRef operator[] (size_t i) {
-        ensureReadyFor(i);
-        return r[i];
-    }
-
-    void insert(PTRef fla, size_t k) {
-        ensureReadyFor(k);
-        PTRef new_fla = logic.mkAnd(r[k], fla);
-        r[k] = new_fla;
-    }
-
-private:
-    std::vector<PTRef> r;
-    Logic & logic;
-
-    void ensureReadyFor(size_t k) {
-        while (k >= r.size()) {
-            r.push_back(logic.getTerm_true());
-        }
-    }
-
-};
-
-/**
- * Each instance builds its own reachability frame and uses it to check if other states are reachable in k steps.
- */
-class ReachabilityChecker {
-private:
-    RFrames r_frames;
-    Logic & logic;
-    TransitionSystem const & system;
-
-    std::tuple<bool, PTRef> reachable(unsigned k, PTRef formula);
-public:
-    ReachabilityChecker(Logic & logic, TransitionSystem const & system) : r_frames(logic), logic(logic), system(system) {}
-    std::tuple<bool, int, PTRef> checkReachability(int from, int to, PTRef formula);
-    PTRef generalize(Model & model, PTRef transition, PTRef formula);
-};
 
 /**
  * Uses PDKind algorithm [1] to solve a transition system.
@@ -136,9 +32,7 @@ class PDKind : public Engine {
         VerificationResult solve(ChcDirectedGraph const & system);
 
     private:
-        PushResult push(TransitionSystem const & system, InductionFrame & iframe, int n, int k, ReachabilityChecker & reachability_checker);
-        TransitionSystemVerificationResult solveTransitionSystem(TransitionSystem const & system);
-        PTRef getInvariant(InductionFrame const & iframe, unsigned int k, TransitionSystem const & system);
+        [[nodiscard]] TransitionSystemVerificationResult solveTransitionSystem(TransitionSystem const & system) const;
 };
 
 #endif // GOLEM_PDKIND_H

--- a/src/utils/ScopeGuard.h
+++ b/src/utils/ScopeGuard.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef SCOPEGUARD_H
+#define SCOPEGUARD_H
+
+#include <utility>
+
+template <typename Func>
+class ScopeGuard {
+public:
+    explicit ScopeGuard(Func&& func) : func(std::forward<Func>(func)) {}
+
+    ~ScopeGuard() { func(); }
+
+    ScopeGuard(const ScopeGuard&) = delete;
+    ScopeGuard& operator=(const ScopeGuard&) = delete;
+
+private:
+    Func func;
+};
+
+#endif //SCOPEGUARD_H


### PR DESCRIPTION
The main change in PDKIND here is to use one solver for the push method incrementally, which avoids quite a lot of repetitive work.
We also use init solver in reachability checks incrementally.
Apart from that, the implementation is refactored to create better (code) abstraction.