### PR TITLE
Preprocessing: Do not try to eliminate all non-loop nodes

### DIFF
--- a/src/engine/Kind.cc
+++ b/src/engine/Kind.cc
@@ -7,7 +7,6 @@
 #include "Kind.h"
 
 #include "Common.h"
-#include "QuantifierElimination.h"
 #include "TermUtils.h"
 #include "transformers/BasicTransformationPipelines.h"
 #include "TransformationUtils.h"

--- a/src/transformers/BasicTransformationPipelines.cc
+++ b/src/transformers/BasicTransformationPipelines.cc
@@ -16,10 +16,45 @@
 #include "TrivialEdgePruner.h"
 
 namespace Transformations {
+
+namespace {
+
+struct SlightlyBetterNodeEliminatorPredicate {
+    bool operator()(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph) const;
+};
+
+bool SlightlyBetterNodeEliminatorPredicate::operator()(
+    SymRef vertex,
+    AdjacencyListsGraphRepresentation const & ar,
+    ChcDirectedHyperGraph const & graph) const {
+    if (not isNonLoopNode(vertex, ar, graph)) { return false; }
+    // Here we do not consider hyperedges anymore
+    if (hasHyperEdge(vertex, ar, graph)) { return false; }
+    // We extend the definition of a simple node such that |incoming| x |outgoing| <= |incoming| + |outgoing|
+    bool isSimple = [&]() {
+        auto outgoingSize = ar.getOutgoingEdgesFor(vertex).size();
+        auto incomingSize = ar.getIncomingEdgesFor(vertex).size();
+        return incomingSize * outgoingSize <= incomingSize + outgoingSize;
+    }();
+    return isSimple;
+}
+
+/**
+ * This node eliminator is designed to eliminate some nodes that SimpleNodeEliminator preserves.
+ * Typical example is head of an outer loop; in graph terminology, node s1 which has one incoming, one outgoing edge,
+ * and then for some s2 there are edges s1 -> s2, s2 -> s2, s2 -> s1.
+ *
+ * For simplicity, we no longer consider hyperedges in this eliminator.
+ */
+class SlightlyBetterNodeEliminator : public NodeEliminator {
+public:
+    SlightlyBetterNodeEliminator() : NodeEliminator(SlightlyBetterNodeEliminatorPredicate{}) {}
+};
+} // namespace
+
 TransformationPipeline towardsTransitionSystems() {
     TransformationPipeline::pipeline_t stages;
-    stages.push_back(std::make_unique<MultiEdgeMerger>());
-    stages.push_back(std::make_unique<NonLoopEliminator>());
+    stages.push_back(std::make_unique<SlightlyBetterNodeEliminator>());
     stages.push_back(std::make_unique<FalseClauseRemoval>());
     stages.push_back(std::make_unique<RemoveUnreachableNodes>());
     stages.push_back(std::make_unique<MultiEdgeMerger>());
@@ -41,7 +76,10 @@ TransformationPipeline defaultTransformationPipeline() {
     stages.push_back(std::make_unique<SimpleChainSummarizer>());
     stages.push_back(std::make_unique<RemoveUnreachableNodes>());
     stages.push_back(std::make_unique<SimpleNodeEliminator>());
+    stages.push_back(std::make_unique<FalseClauseRemoval>());
+    stages.push_back(std::make_unique<RemoveUnreachableNodes>());
     stages.push_back(std::make_unique<MultiEdgeMerger>());
+    stages.push_back(std::make_unique<TrivialEdgePruner>());
     return TransformationPipeline(std::move(stages));
 }
 } // namespace Transformations

--- a/src/transformers/NodeEliminator.cc
+++ b/src/transformers/NodeEliminator.cc
@@ -39,14 +39,6 @@ Transformer::TransformationResult NodeEliminator::transform(std::unique_ptr<ChcD
     return {std::move(graph), std::move(backTranslator)};
 }
 
-bool NonLoopEliminatorPredicate::operator()(
-    SymRef vertex,
-    AdjacencyListsGraphRepresentation const & ar,
-    ChcDirectedHyperGraph const & graph) const {
-    // TODO: Remove the constraint about hyperEdge
-    return not hasHyperEdge(vertex, ar, graph) and isNonLoopNode(vertex, ar, graph);
-}
-
 bool SimpleNodeEliminatorPredicate::operator()(
     SymRef vertex,
     AdjacencyListsGraphRepresentation const & ar,

--- a/src/transformers/NodeEliminator.h
+++ b/src/transformers/NodeEliminator.h
@@ -17,7 +17,7 @@
 class NodeEliminator : public Transformer {
     using predicate_t = std::function<bool(SymRef,AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const &)>;
 public:
-    NodeEliminator(predicate_t shouldEliminateNode) : shouldEliminateNode(std::move(shouldEliminateNode)) {}
+    explicit NodeEliminator(predicate_t shouldEliminateNode) : shouldEliminateNode(std::move(shouldEliminateNode)) {}
 
     TransformationResult transform(std::unique_ptr<ChcDirectedHyperGraph> graph) override;
 
@@ -41,15 +41,6 @@ public:
     };
 
     predicate_t shouldEliminateNode;
-};
-
-struct NonLoopEliminatorPredicate {
-    bool operator()(SymRef, AdjacencyListsGraphRepresentation const &, ChcDirectedHyperGraph const & graph) const;
-};
-
-class NonLoopEliminator : public NodeEliminator {
-public:
-    NonLoopEliminator() : NodeEliminator(NonLoopEliminatorPredicate{}) {}
 };
 
 struct SimpleNodeEliminatorPredicate {

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -434,51 +434,6 @@ TEST_F(Transformer_test, test_ChainSummarizer_UnreachableLoop) {
     ASSERT_EQ(summarizedGraph->getEdges().size(), 2);
 }
 
-TEST_F(Transformer_test, test_NonLoopEliminator_SuccessfulElimination) {
-    ChcSystem system;
-    system.addUninterpretedPredicate(s1);
-    system.addClause( // x' >= 0 => S1(x')
-        ChcHead{UninterpretedPredicate{nextS1}},
-        ChcBody{{logic.mkGeq(xp, zero)}, {}});
-    system.addClause( // S1(x) => false
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.getTerm_true()}, {UninterpretedPredicate{currentS1}}}
-    );
-    auto hyperGraph = systemToGraph(system);
-    auto entry = hyperGraph->getEntry();
-    auto exit = hyperGraph->getExit();
-    ASSERT_EQ(hyperGraph->getEdges().size(), 2);
-    NonLoopEliminator transformation;
-    auto [transformedGraph, backtranslator] = transformation.transform(std::move(hyperGraph));
-    auto edges = transformedGraph->getEdges();
-    ASSERT_EQ(edges.size(), 1);
-    auto const & edge = edges[0];
-    ASSERT_EQ(edge.from.size(), 1);
-    EXPECT_EQ(edge.to, exit);
-    EXPECT_EQ(edge.from[0], entry);
-}
-
-TEST_F(Transformer_test, test_NonLoopEliminator_NoElimination) {
-    ChcSystem system;
-    system.addUninterpretedPredicate(s1);
-    system.addClause( // x' >= 0 => S1(x')
-        ChcHead{UninterpretedPredicate{nextS1}},
-        ChcBody{{logic.mkGeq(xp, zero)}, {}});
-    system.addClause( // S1(x) and x' = x + 1 => S1(x')
-        ChcHead{UninterpretedPredicate{nextS1}},
-        ChcBody{{logic.mkEq(xp, logic.mkPlus(x, one))}, {UninterpretedPredicate{currentS1}}});
-    system.addClause( // S1(x) => false
-        ChcHead{UninterpretedPredicate{logic.getTerm_false()}},
-        ChcBody{{logic.getTerm_true()}, {UninterpretedPredicate{currentS1}}}
-    );
-    auto hyperGraph = systemToGraph(system);
-    ASSERT_EQ(hyperGraph->getEdges().size(), 3);
-    NonLoopEliminator transformation;
-    auto [transformedGraph, backtranslator] = transformation.transform(std::move(hyperGraph));
-    auto edges = transformedGraph->getEdges();
-    ASSERT_EQ(edges.size(), 3);
-}
-
 TEST_F(Transformer_test, test_NodeEliminator_PredicateWithoutVariables) {
     SymRef t_sym = logic.declareFun("t", logic.getSort_bool(), {});
     PTRef t = logic.mkUninterpFun(t_sym, {});


### PR DESCRIPTION
I believe the rationale for for this transformation was to get as close to a transition system (or DAG of transition systems) as possible. However, trying to eliminate all non-looping nodes can lead to an explosion in the number of edges, and sometimes even this transformation itself does not finish. For example, if a node has more than 1000 incoming and outgoing edges it would have to create more than 1 000 000 edges to eliminate such a node.