### PR TITLE
Engines: Unify first phase of engines that operate on transition systems

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(golem_lib PUBLIC OpenSMT::OpenSMT)
 target_sources(golem_lib
     PRIVATE ChcSystem.cc
     PRIVATE ChcInterpreter.cc
+    PRIVATE engine/ArgBasedEngine.cc
     PRIVATE engine/Bmc.cc
     PRIVATE engine/Common.cc
     PRIVATE engine/DAR.cc
@@ -41,7 +42,7 @@ target_sources(golem_lib
     PRIVATE engine/PDKind.cc
     PRIVATE engine/Spacer.cc
     PRIVATE engine/TPA.cc
-    PRIVATE engine/ArgBasedEngine.cc
+    PRIVATE engine/TransitionSystemEngine.cc
     PRIVATE TransitionSystem.cc
     PRIVATE Options.cc
     PRIVATE TermUtils.cc

--- a/src/engine/DAR.cc
+++ b/src/engine/DAR.cc
@@ -9,24 +9,7 @@
 #include "Common.h"
 #include "TransformationUtils.h"
 
-#include "transformers/SingleLoopTransformation.h"
 #include "utils/SmtSolver.h"
-
-VerificationResult DAR::solve(ChcDirectedGraph const & graph) {
-    if (isTrivial(graph)) { return solveTrivial(graph); }
-    if (isTransitionSystem(graph)) { return solveTransitionSystem(graph); }
-    SingleLoopTransformation transformation;
-    auto [ts, backtranslator] = transformation.transform(graph);
-    assert(ts);
-    auto res = solveTransitionSystemInternal(*ts);
-    return computeWitness ? backtranslator->translate(res) : VerificationResult(res.answer);
-}
-
-VerificationResult DAR::solveTransitionSystem(ChcDirectedGraph const & graph) {
-    auto ts = toTransitionSystem(graph);
-    auto res = solveTransitionSystemInternal(*ts);
-    return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
-}
 
 class DualApproximatedReachability {
 public:
@@ -62,7 +45,7 @@ private:
     void showSequences() const;
 };
 
-TransitionSystemVerificationResult DAR::solveTransitionSystemInternal(TransitionSystem const & system) {
+TransitionSystemVerificationResult DAR::solve(TransitionSystem const & system) {
     { // Check satisfiability of Init /\ Query
         SMTSolver solver(logic, SMTSolver::WitnessProduction::NONE);
         solver.assertProp(system.getInit());

--- a/src/engine/DAR.h
+++ b/src/engine/DAR.h
@@ -4,33 +4,21 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "Engine.h"
-
 #ifndef DAR_H
 #define DAR_H
 
-class DAR : public Engine {
+#include "TransitionSystemEngine.h"
+
+class DAR : public TransitionSystemEngine {
     Logic & logic;
-    bool computeWitness = false;
 
 public:
     DAR(Logic & logic, Options const & options) : logic(logic) {
         computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
     }
 
-    VerificationResult solve(ChcDirectedHyperGraph const & graph) override {
-        if (graph.isNormalGraph()) {
-            auto normalGraph = graph.toNormalGraph();
-            return solve(*normalGraph);
-        }
-        return VerificationResult(VerificationAnswer::UNKNOWN);
-    }
-
-    VerificationResult solve(ChcDirectedGraph const & graph);
-
 private:
-    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
-    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
+    TransitionSystemVerificationResult solve(TransitionSystem const & system) override;
 };
 
 #endif // DAR_H

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -1,19 +1,16 @@
 /*
-* Copyright (c) 2020-2023, Martin Blicha <martin.blicha@gmail.com>
+* Copyright (c) 2020-2025, Martin Blicha <martin.blicha@gmail.com>
 *
 * SPDX-License-Identifier: MIT
 */
 
-#ifndef OPENSMT_ENGINE_H
-#define OPENSMT_ENGINE_H
+#ifndef GOLEM_ENGINE_H
+#define GOLEM_ENGINE_H
 
-#include "Witnesses.h"
 #include "Options.h"
+#include "Witnesses.h"
 #include "graph/ChcGraph.h"
 
-#include "osmt_terms.h"
-
-#include <memory>
 
 class Engine {
 public:
@@ -24,4 +21,4 @@ public:
     virtual ~Engine() = default;
 };
 
-#endif //OPENSMT_ENGINE_H
+#endif //GOLEM_ENGINE_H

--- a/src/engine/IMC.cc
+++ b/src/engine/IMC.cc
@@ -13,23 +13,7 @@
 #include "transformers/SingleLoopTransformation.h"
 #include "utils/SmtSolver.h"
 
-VerificationResult IMC::solve(ChcDirectedGraph const & graph) {
-    if (isTrivial(graph)) { return solveTrivial(graph); }
-    if (isTransitionSystem(graph)) { return solveTransitionSystem(graph); }
-    SingleLoopTransformation transformation;
-    auto [ts, backtranslator] = transformation.transform(graph);
-    assert(ts);
-    auto res = solveTransitionSystemInternal(*ts);
-    return computeWitness ? backtranslator->translate(res) : VerificationResult(res.answer);
-}
-
-VerificationResult IMC::solveTransitionSystem(ChcDirectedGraph const & graph) {
-    auto ts = toTransitionSystem(graph);
-    auto res = solveTransitionSystemInternal(*ts);
-    return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
-}
-
-TransitionSystemVerificationResult IMC::solveTransitionSystemInternal(TransitionSystem const & system) {
+TransitionSystemVerificationResult IMC::solve(TransitionSystem const & system) {
     { // if I /\ F is Satisfiable, return true
         SMTSolver solver(logic, SMTSolver::WitnessProduction::NONE);
         solver.assertProp(system.getInit());

--- a/src/engine/IMC.h
+++ b/src/engine/IMC.h
@@ -8,15 +8,15 @@
 #ifndef GOLEM_IMC_H
 #define GOLEM_IMC_H
 
-#include "Engine.h"
 #include "TransitionSystem.h"
+#include "TransitionSystemEngine.h"
+
 #include "osmt_solver.h"
 
-class IMC : public Engine {
+class IMC : public TransitionSystemEngine {
     Logic & logic;
     // Options const & options;
     int verbosity = 0;
-    bool computeWitness = false;
 
 public:
     IMC(Logic & logic, Options const & options) : logic(logic) {
@@ -24,19 +24,10 @@ public:
         computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
     }
 
-    virtual VerificationResult solve(ChcDirectedHyperGraph const & graph) override {
-        if (graph.isNormalGraph()) {
-            auto normalGraph = graph.toNormalGraph();
-            return solve(*normalGraph);
-        }
-        return VerificationResult(VerificationAnswer::UNKNOWN);
-    }
-
-    VerificationResult solve(ChcDirectedGraph const & graph);
+    using TransitionSystemEngine::solve;
 
 private:
-    VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);
-    TransitionSystemVerificationResult solveTransitionSystemInternal(TransitionSystem const & system);
+    TransitionSystemVerificationResult solve(TransitionSystem const & system) override;
 
     TransitionSystemVerificationResult finiteRun(TransitionSystem const & ts, unsigned k);
 

--- a/src/engine/Kind.cc
+++ b/src/engine/Kind.cc
@@ -12,19 +12,6 @@
 #include "TransformationUtils.h"
 #include "utils/SmtSolver.h"
 
-VerificationResult Kind::solve(ChcDirectedHyperGraph const & graph) {
-    auto pipeline = Transformations::towardsTransitionSystems();
-    auto transformationResult = pipeline.transform(std::make_unique<ChcDirectedHyperGraph>(graph));
-    auto transformedGraph = std::move(transformationResult.first);
-    auto translator = std::move(transformationResult.second);
-    if (transformedGraph->isNormalGraph()) {
-        auto normalGraph = transformedGraph->toNormalGraph();
-        auto res = solve(*normalGraph);
-        return computeWitness ? translator->translate(std::move(res)) : std::move(res);
-    }
-    return VerificationResult(VerificationAnswer::UNKNOWN);
-}
-
 VerificationResult Kind::solve(ChcDirectedGraph const & graph) {
     if (isTrivial(graph)) {
         return solveTrivial(graph);

--- a/src/engine/Kind.h
+++ b/src/engine/Kind.h
@@ -9,14 +9,13 @@
 
 
 
-#include "Engine.h"
+#include "TransitionSystemEngine.h"
 #include "TransitionSystem.h"
 
-class Kind : public Engine {
+class Kind : public TransitionSystemEngine {
     Logic & logic;
 //    Options const & options;
     int verbosity {0};
-    bool computeWitness {false};
 public:
 
     Kind(Logic & logic, Options const & options) : logic(logic) {
@@ -24,9 +23,8 @@ public:
         computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
     }
 
-    virtual VerificationResult solve(ChcDirectedHyperGraph const & graph) override;
 
-    VerificationResult solve(ChcDirectedGraph const & graph);
+    VerificationResult solve(ChcDirectedGraph const & graph) override;
 
 private:
     VerificationResult solveTransitionSystem(ChcDirectedGraph const & graph);

--- a/src/engine/PDKind.cc
+++ b/src/engine/PDKind.cc
@@ -20,34 +20,6 @@
 #include <set>
 #include <tuple>
 
-VerificationResult PDKind::solve(ChcDirectedHyperGraph const & graph) {
-    auto pipeline = Transformations::towardsTransitionSystems();
-    auto transformationResult = pipeline.transform(std::make_unique<ChcDirectedHyperGraph>(graph));
-    auto transformedGraph = std::move(transformationResult.first);
-    auto translator = std::move(transformationResult.second);
-    if (transformedGraph->isNormalGraph()) {
-        auto normalGraph = transformedGraph->toNormalGraph();
-        auto res = solve(*normalGraph);
-        return computeWitness ? translator->translate(std::move(res)) : std::move(res);
-    }
-    return VerificationResult(VerificationAnswer::UNKNOWN);
-}
-
-VerificationResult PDKind::solve(ChcDirectedGraph const & system) {
-    if (isTrivial(system)) {
-        return solveTrivial(system);
-    }
-    if (isTransitionSystem(system)) {
-        auto ts = toTransitionSystem(system);
-        auto res = solveTransitionSystem(*ts);
-        return computeWitness ? translateTransitionSystemResult(res, system, *ts) : VerificationResult(res.answer);
-    }
-    SingleLoopTransformation transformation;
-    auto[ts, backtranslator] = transformation.transform(system);
-    assert(ts);
-    auto res = solveTransitionSystem(*ts);
-    return computeWitness ? backtranslator->translate(res) : VerificationResult(res.answer);
-}
 
 /**
  * Counter example formula in addition with number of steps needed to reach the counter example.
@@ -202,7 +174,7 @@ private:
     PTRef getInvariant(InductionFrame const & iframe, unsigned int k, TransitionSystem const & system) const;
 };
 
-TransitionSystemVerificationResult PDKind::solveTransitionSystem(TransitionSystem const & system) const {
+TransitionSystemVerificationResult PDKind::solve(TransitionSystem const & system) {
     return Context(logic, computeWitness).solve(system);
 }
 

--- a/src/engine/PDKind.h
+++ b/src/engine/PDKind.h
@@ -7,7 +7,7 @@
 #ifndef GOLEM_PDKIND_H
 #define GOLEM_PDKIND_H
 
-#include "Engine.h"
+#include "TransitionSystemEngine.h"
 #include "TransitionSystem.h"
 
 
@@ -16,23 +16,17 @@
  *
  * [1] https://ieeexplore.ieee.org/document/7886665
  */
-class PDKind : public Engine {
+class PDKind : public TransitionSystemEngine {
         Logic & logic;
-        bool computeWitness {false};
     public:
-
         PDKind (Logic & logic, Options const & options) : logic(logic) {
             if (options.hasOption(Options::COMPUTE_WITNESS)) {
                 computeWitness = options.getOption(Options::COMPUTE_WITNESS) == "true";
             }
         }
 
-        VerificationResult solve(ChcDirectedHyperGraph const & graph) override;
-
-        VerificationResult solve(ChcDirectedGraph const & system);
-
     private:
-        [[nodiscard]] TransitionSystemVerificationResult solveTransitionSystem(TransitionSystem const & system) const;
+        [[nodiscard]] TransitionSystemVerificationResult solve(TransitionSystem const & system) override;
 };
 
 #endif // GOLEM_PDKIND_H

--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -26,10 +26,6 @@
 const std::string TPAEngine::TPA = "tpa";
 const std::string TPAEngine::SPLIT_TPA = "split-tpa";
 
-bool TPAEngine::shouldComputeWitness() const {
-    return options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
-}
-
 std::unique_ptr<TPABase> TPAEngine::mkSolver() {
     switch (coreAlgorithm) {
         case TPACore::BASIC:
@@ -38,19 +34,6 @@ std::unique_ptr<TPABase> TPAEngine::mkSolver() {
             return std::make_unique<TPASplit>(logic, options);
     }
     throw std::logic_error("UNREACHABLE");
-}
-
-VerificationResult TPAEngine::solve(ChcDirectedHyperGraph const & graph) {
-    auto pipeline = Transformations::towardsTransitionSystems();
-    auto transformationResult = pipeline.transform(std::make_unique<ChcDirectedHyperGraph>(graph));
-    auto transformedGraph = std::move(transformationResult.first);
-    auto translator = std::move(transformationResult.second);
-    if (transformedGraph->isNormalGraph()) {
-        auto normalGraph = transformedGraph->toNormalGraph();
-        auto res = solve(*normalGraph);
-        return shouldComputeWitness() ? translator->translate(std::move(res)) : std::move(res);
-    }
-    return VerificationResult(VerificationAnswer::UNKNOWN);
 }
 
 VerificationResult TPAEngine::solve(const ChcDirectedGraph & graph) {

--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -7,7 +7,7 @@
 #ifndef GOLEM_TPA_H
 #define GOLEM_TPA_H
 
-#include "Engine.h"
+#include "TransitionSystemEngine.h"
 
 #include "osmt_solver.h"
 
@@ -31,7 +31,7 @@ class TPABase;
 
 enum class TPACore { BASIC, SPLIT };
 
-class TPAEngine : public Engine {
+class TPAEngine : public TransitionSystemEngine {
     Logic & logic;
     Options options;
     TPACore coreAlgorithm;
@@ -39,18 +39,18 @@ class TPAEngine : public Engine {
 
 public:
     TPAEngine(Logic & logic, Options options, TPACore core)
-        : logic(logic), options(std::move(options)), coreAlgorithm(core) {}
+        : logic(logic), options(std::move(options)), coreAlgorithm(core) {
+        computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
+    }
 
-    VerificationResult solve(ChcDirectedHyperGraph const & graph) override;
+    VerificationResult solve(ChcDirectedGraph const & graph) override;
 
     static const std::string TPA;
     static const std::string SPLIT_TPA;
 
-    [[nodiscard]] bool shouldComputeWitness() const;
+    [[nodiscard]] bool shouldComputeWitness() const { return computeWitness; }
 
 private:
-    VerificationResult solve(const ChcDirectedGraph & system);
-
     std::unique_ptr<TPABase> mkSolver();
 
     VerificationResult solveTransitionSystemGraph(ChcDirectedGraph const & graph);

--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -40,9 +40,10 @@ class TPAEngine : public TransitionSystemEngine {
 public:
     TPAEngine(Logic & logic, Options options, TPACore core)
         : logic(logic), options(std::move(options)), coreAlgorithm(core) {
-        computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
+        computeWitness = this->options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
     }
 
+    using TransitionSystemEngine::solve;
     VerificationResult solve(ChcDirectedGraph const & graph) override;
 
     static const std::string TPA;

--- a/src/engine/TransitionSystemEngine.cc
+++ b/src/engine/TransitionSystemEngine.cc
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#include "TransitionSystemEngine.h"
+
+#include "Common.h"
+#include "TransformationUtils.h"
+#include "TransitionSystem.h"
+#include "transformers/BasicTransformationPipelines.h"
+#include "transformers/SingleLoopTransformation.h"
+
+VerificationResult TransitionSystemEngine::solve(ChcDirectedHyperGraph const & graph) {
+    auto pipeline = Transformations::towardsTransitionSystems();
+    auto transformationResult = pipeline.transform(std::make_unique<ChcDirectedHyperGraph>(graph));
+    auto transformedGraph = std::move(transformationResult.first);
+    auto translator = std::move(transformationResult.second);
+    if (transformedGraph->isNormalGraph()) {
+        auto normalGraph = transformedGraph->toNormalGraph();
+        auto res = solve(*normalGraph);
+        return computeWitness ? translator->translate(std::move(res)) : std::move(res);
+    }
+    return VerificationResult(VerificationAnswer::UNKNOWN);
+}
+
+VerificationResult TransitionSystemEngine::solve(ChcDirectedGraph const & graph) {
+    if (isTrivial(graph)) {
+        return solveTrivial(graph);
+    }
+    if (isTransitionSystem(graph)) {
+        auto ts = toTransitionSystem(graph);
+        auto res = solve(*ts);
+        return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
+    }
+    SingleLoopTransformation transformation;
+    auto[ts, backtranslator] = transformation.transform(graph);
+    assert(ts);
+    auto res = solve(*ts);
+    return computeWitness ? backtranslator->translate(res) : VerificationResult(res.answer);
+}
+
+TransitionSystemVerificationResult TransitionSystemEngine::solve(TransitionSystem const &) {
+    return {VerificationAnswer::UNKNOWN, {0u}};
+}
+
+

--- a/src/engine/TransitionSystemEngine.h
+++ b/src/engine/TransitionSystemEngine.h
@@ -1,0 +1,22 @@
+/*
+* Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#ifndef TRANSITIONSYSTEMENGINE_H
+#define TRANSITIONSYSTEMENGINE_H
+
+#include "Engine.h"
+
+class TransitionSystemEngine : public Engine {
+public:
+    VerificationResult solve(ChcDirectedHyperGraph const &) override;
+    virtual VerificationResult solve(ChcDirectedGraph const &);
+    virtual TransitionSystemVerificationResult solve(TransitionSystem const &);
+
+protected:
+    bool computeWitness{false};
+};
+
+#endif //TRANSITIONSYSTEMENGINE_H

--- a/test/test_Transformers.cc
+++ b/test/test_Transformers.cc
@@ -493,6 +493,7 @@ TEST_F(Transformer_New_Test, test_NodeEliminator_SecondEdgeUsed) {
     SimpleNodeEliminator transformation;
     auto [transformedGraph, translator] = transformation.transform(std::move(hyperGraph));
     ASSERT_EQ(transformedGraph->getEdges().size(), 2);
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     auto res = IMC(logic, options).solve(*transformedGraph);
     auto answer = res.getAnswer();
     ASSERT_EQ(answer, VerificationAnswer::UNSAFE);


### PR DESCRIPTION
Engines that operate on transition system shared the code how to get to a transition system from `CHCDirectedHyperGraph`.
We refactor that code to a common superclass, while still allowing engines to customize individual steps of the transformation.