### PR TITLE
PA: Use batched processing in entailment checks

### DIFF
--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -827,7 +827,7 @@ vec<PTRef> ARG::computePropagatedPredicates(C const & candidates, std::vector<No
                                             PTRef edgeConstraint) const {
     Logic & logic = clauses.getLogic();
     VersionManager versionManager{logic};
-    PTRef const assertion = [&]() {
+    vec<PTRef> assertions = [&]() {
         std::unordered_map<SymRef, int, SymRefHash> sourcesCount;
         vec<PTRef> components{edgeConstraint};
         for (auto const sourceId : sources) {
@@ -836,14 +836,14 @@ vec<PTRef> ARG::computePropagatedPredicates(C const & candidates, std::vector<No
                 versionManager.baseFormulaToSource(reachedStates, sourcesCount[getPredicateSymbol(sourceId)]++);
             components.push(versioned);
         }
-        return logic.mkAnd(std::move(components));
+        return components;
     }();
     vec<PTRef> candidatesVec;
     for (PTRef const candidate : candidates) {
         PTRef versionedPredicate = versionManager.baseFormulaToTarget(candidate);
         candidatesVec.push(versionedPredicate);
     }
-    auto impliedPredicates = impliedBy(std::move(candidatesVec), assertion, logic);
+    auto impliedPredicates = impliedBy(std::move(candidatesVec), assertions, logic);
     for (PTRef & predicate : impliedPredicates) {
         predicate = versionManager.targetFormulaToBase(predicate);
     }

--- a/src/engine/Spacer.cc
+++ b/src/engine/Spacer.cc
@@ -592,58 +592,21 @@ bool SpacerContext::tryPushComponents(SymRef vid, std::size_t level, PTRef body)
     auto maySummaryComponents = over.getComponents(vid, level);
     vec<PTRef> targetCandidates;
     targetCandidates.capacity(maySummaryComponents.size());
-    vec<PTRef> activationLiterals;
-    activationLiterals.capacity(maySummaryComponents.size());
-    unsigned counter = 0;
-    for (PTRef component : maySummaryComponents) {
+    for (PTRef const component : maySummaryComponents) {
         if (over.has(vid, level + 1, component)) {
             continue;
         }
-        std::string name = ".act" + std::to_string(counter++);
-        PTRef activationVariable = logic.mkBoolVar(name.c_str());
         targetCandidates.push(VersionManager(logic).baseFormulaToTarget(component));
-        activationLiterals.push(activationVariable);
     }
-    if (targetCandidates.size() == 0) { return true; }
+    std::size_t const candidatesCount = targetCandidates.size_();
+    if (candidatesCount == 0) { return true; }
 
-    bool allPushed = true;
-    SMTSolver solver(logic, SMTSolver::WitnessProduction::ONLY_MODEL);
-    solver.assertProp(body);
-    vec<PTRef> queries;
-    queries.capacity(targetCandidates.size());
-    for (auto i = 0; i < targetCandidates.size(); ++i) {
-        queries.push(logic.mkAnd(activationLiterals[i], logic.mkNot(targetCandidates[i])));
-    }
-    solver.assertProp(logic.mkOr(queries));
+    auto pushed = impliedBy(std::move(targetCandidates), body, logic);
 
-    auto disabled = 0u;
-    while (disabled < queries.size_()) {
-        solver.push();
-        solver.assertProp(logic.mkAnd(activationLiterals));
-        auto res = solver.check();
-        if (res == SMTSolver::Answer::UNSAT) { break; }
-        assert(res == SMTSolver::Answer::SAT);
-        if (res != SMTSolver::Answer::SAT) { throw std::logic_error("Solver could not solve a problem while trying to push components!"); }
-        auto model = solver.getModel();
-        for (auto i = 0; i < activationLiterals.size(); ++i) {
-            if (logic.isNot(activationLiterals[i])) { continue; } // already disabled
-            if (model->evaluate(queries[i]) == logic.getTerm_true()) {
-                ++disabled;
-                assert(not logic.isNot(activationLiterals[i]));
-                activationLiterals[i] = logic.mkNot(activationLiterals[i]);
-            }
-        }
-        solver.pop();
+    for (PTRef const lemma : pushed) {
+        addMaySummary(vid, level + 1, VersionManager(logic).targetFormulaToBase(lemma));
     }
-
-    for (auto i = 0; i < targetCandidates.size(); ++i) {
-        if (not logic.isNot(activationLiterals[i])) {
-            addMaySummary(vid, level + 1, VersionManager(logic).targetFormulaToBase(targetCandidates[i]));
-        } else {
-            allPushed = false;
-        }
-    }
-    return allPushed;
+    return pushed.size_() == candidatesCount;
 }
 
 

--- a/src/utils/SmtSolver.h
+++ b/src/utils/SmtSolver.h
@@ -44,5 +44,6 @@ public:
 
 using Formulas = vec<PTRef>;
 Formulas impliedBy(Formulas candidates, PTRef assertion, Logic & logic);
+Formulas impliedBy(Formulas candidates, vec<PTRef> const & assertions, Logic & logic);
 
 #endif // GOLEM_SMTSOLVER_H

--- a/src/utils/SmtSolver.h
+++ b/src/utils/SmtSolver.h
@@ -42,4 +42,7 @@ public:
     SMTConfig & getConfig() { return config; }
 };
 
+using Formulas = vec<PTRef>;
+Formulas impliedBy(Formulas candidates, PTRef assertion, Logic & logic);
+
 #endif // GOLEM_SMTSOLVER_H


### PR DESCRIPTION
We reuse the same functionality we are already using in Spacer.

The results are somewhat mixed.
It seems the checks can be harder than when the lemmas are checked one by one.

We could experiment further by recursively splitting the formulas being checked and only perform the current method on small sets of formulas.