### PR TITLE
KIND: Init and query must not contain auxiliary variables

### DIFF
--- a/src/TransformationUtils.h
+++ b/src/TransformationUtils.h
@@ -22,6 +22,8 @@ bool isTrivial(ChcDirectedGraph const & graph);
 
 std::unique_ptr<TransitionSystem> toTransitionSystem(ChcDirectedGraph const & graph);
 
+std::unique_ptr<TransitionSystem> ensureNoAuxiliaryVariablesInInitAndQuery(std::unique_ptr<TransitionSystem> ts);
+
 struct EdgeVariables {
     std::vector<PTRef> stateVars;
     std::vector<PTRef> nextStateVars;

--- a/src/engine/Kind.cc
+++ b/src/engine/Kind.cc
@@ -33,6 +33,7 @@ VerificationResult Kind::solve(ChcDirectedGraph const & graph) {
 
 VerificationResult Kind::solveTransitionSystem(ChcDirectedGraph const & graph) {
     auto ts = toTransitionSystem(graph);
+    ts = ensureNoAuxiliaryVariablesInInitAndQuery(std::move(ts));
     auto res = solveTransitionSystemInternal(*ts);
     return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
 }


### PR DESCRIPTION
K-induction checks, as implemented, require satisfiability checks where the init and query states are negated.
If they would contain auxiliary variables, these would have to be universally quantified in the negations.
Treating them as existentially quantified changes the meaning of the checks. For this reason, we need to fully eliminate auxiliary variables from Init and Query in the KIND engine.

This basically reverts the change made in 9811d3a for KIND, but keeps it for other engines where the same issue does not apply.