### PR TITLE
TPA: Init and query must not contain auxiliary variables

### DIFF
--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -41,6 +41,7 @@ VerificationResult TPAEngine::solve(const ChcDirectedGraph & graph) {
     if (logic.hasArrays()) { return VerificationResult{VerificationAnswer::UNKNOWN}; }
     if (isTransitionSystem(graph)) {
         auto ts = toTransitionSystem(graph);
+        ts = ensureNoAuxiliaryVariablesInInitAndQuery(std::move(ts));
         auto solver = mkSolver();
         auto res = solver->solveTransitionSystem(*ts);
         if (not shouldComputeWitness()) { return VerificationResult(res); }


### PR DESCRIPTION
Current implementation of the algorithm assumes that there are no auxiliary variables in init and query.
We need to check where exactly this is needed and see if we can relax this restriction.