### PR TITLE
Engines: Add new engine based on forward symbolic execution

### DIFF
--- a/.clang-files
+++ b/.clang-files
@@ -22,6 +22,8 @@ src/engine/Lawi.cc
 src/engine/Lawi.h
 src/engine/PDKind.cc
 src/engine/PDKind.h
+src/engine/SymbolicExecution.cc
+src/engine/SymbolicExecution.h
 src/engine/Spacer.cc
 src/engine/Spacer.h
 src/engine/TPA.cc

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ It works on transition system, but it can handle linear systems of Horn clauses 
 The PA engine is a simple prototype of a [predicate abstraction](https://link.springer.com/chapter/10.1007/3-540-63166-6_10) with [CEGAR](https://link.springer.com/chapter/10.1007/10722167_15).
 The implementation is still rather naive, but the algorithm can handle all (even nonlinear) CHC systems.
 
-
 ### Property-directed k-induction
 
 The implementation of PDKIND follows the description of the algorithm in [this paper](https://ieeexplore.ieee.org/document/7886665).
 It works on transition system, but it can handle linear systems of Horn clauses by first transforming them into a simple transition system.
+
+### Symbolic Execution
+Following the description from [this paper](https://link.springer.com/chapter/10.1007/978-3-031-50524-9_13), symbolic execution engine implements a *forward* exploration of the reachability graph where reachable nodes are characterized precisely by their path formula (non-current-state variables are implicitly existentially quantified).
+Current implementation supports only linear CHC systems.
 
 ### Transition Power Abstraction
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(golem_lib
     PRIVATE engine/Lawi.cc
     PRIVATE engine/PDKind.cc
     PRIVATE engine/Spacer.cc
+    PRIVATE engine/SymbolicExecution.cc
     PRIVATE engine/TPA.cc
     PRIVATE engine/TransitionSystemEngine.cc
     PRIVATE TransitionSystem.cc

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -44,6 +44,7 @@ void printUsage() {
            "                             lawi - Lazy Abstraction with Interpolants (only linear systems)\n"
            "                             pa - basic predicate abstraction with CEGAR (any system)\n"
            "                             pdkind - Property directed k-induction (only linear systems)\n"
+           "                             se - forward symbolic execution (only linear system)\n"
            "                             spacer - custom implementation of Spacer (any system)\n"
            "                             split-tpa - Split Transition Power Abstraction (only linear systems)\n"
            "                             tpa - Transition Power Abstraction (only linear systems)\n"

--- a/src/TermUtils.h
+++ b/src/TermUtils.h
@@ -140,10 +140,13 @@ public:
 
     void printTermWithLets(std::ostream & out, PTRef term);
 
-    PTRef simplifyMax(PTRef root) {
+    [[nodiscard]] PTRef simplifyMax(PTRef const root) const {
         if (logic.isAnd(root) or logic.isOr(root)) {
-            root = ::rewriteMaxArityAggresive(logic, root);
-            return ::simplifyUnderAssignment_Aggressive(root, logic);
+            PTRef const flattened = ::rewriteMaxArityAggresive(logic, root);
+            if (logic.isAnd(flattened) or logic.isOr(flattened)) {
+                return ::simplifyUnderAssignment_Aggressive(flattened, logic);
+            }
+            return flattened;
         }
         return root;
     }

--- a/src/engine/EngineFactory.cc
+++ b/src/engine/EngineFactory.cc
@@ -14,6 +14,7 @@
 #include "Lawi.h"
 #include "PDKind.h"
 #include "Spacer.h"
+#include "SymbolicExecution.h"
 #include "TPA.h"
 
 namespace golem {
@@ -38,6 +39,8 @@ std::unique_ptr<Engine> EngineFactory::getEngine(std::string_view engine) && {
         return std::make_unique<PDKind>(logic, options);
     } else if (engine == "pa") {
         return std::make_unique<ARGBasedEngine>(logic, options);
+    } else if (engine == "se") {
+        return std::make_unique<SymbolicExecution>(logic, options);
     } else {
         throw std::invalid_argument("Unknown engine specified");
     }

--- a/src/engine/SymbolicExecution.cc
+++ b/src/engine/SymbolicExecution.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "SymbolicExecution.h"
+
+#include "graph/ChcGraph.h"
+#include "utils/SmtSolver.h"
+
+namespace golem {
+
+class DirectForwardSymbolicExecution {
+public:
+    explicit DirectForwardSymbolicExecution(std::unique_ptr<ChcDirectedGraph> graph) : graph(std::move(graph)) {}
+    VerificationResult run();
+private:
+    std::unique_ptr<ChcDirectedGraph> graph;
+};
+
+VerificationResult DirectForwardSymbolicExecution::run() {
+    enum class InsertionResult { NEW, DUPLICATE };
+    using Entry = std::pair<SymRef, PTRef>;
+    struct DiscoveredArgNodes {
+        InsertionResult tryInsert(Entry const & entry) {
+            return tryInsert(entry.first, entry.second);
+        }
+        InsertionResult tryInsert(SymRef node, PTRef state) {
+            const auto [_, inserted] = nodes[node].insert(state);
+            return inserted ? InsertionResult::NEW : InsertionResult::DUPLICATE;
+        }
+    private:
+        std::unordered_map<SymRef, std::unordered_set<PTRef, PTRefHash>, SymRefHash> nodes;
+    };
+    using Queue = std::deque<Entry>;
+    Queue q;
+    DiscoveredArgNodes nodes;
+    Logic & logic = graph->getLogic();
+    AdjacencyListsGraphRepresentation ar = AdjacencyListsGraphRepresentation::from(*graph);
+    TermUtils utils(logic);
+
+    q.emplace_back(graph->getEntry(), logic.getTerm_true());
+    nodes.tryInsert(q.back());
+    while (not q.empty()) {
+        auto [node, state] = q.front();
+        q.pop_front();
+        for (EId eid : ar.getOutgoingEdgesFor(node)) {
+            auto target = graph->getTarget(eid);
+            PTRef label = graph->getEdgeLabel(eid);
+            if (target == graph->getExit()) {
+                SMTSolver solver{logic, SMTSolver::WitnessProduction::NONE};
+                solver.assertProp(state);
+                solver.assertProp(label);
+                auto res = solver.check();
+                if (res == SMTSolver::Answer::SAT) { return VerificationResult{VerificationAnswer::UNSAFE}; }
+                if (res != SMTSolver::Answer::UNSAT) { return VerificationResult{VerificationAnswer::UNKNOWN}; }
+                continue;
+            }
+            PTRef rawState = utils.simplifyMax(logic.mkAnd(state, label));
+
+            PTRef rawSimplified = TrivialQuantifierElimination(logic).tryEliminateVarsExcept(
+                TermUtils(logic).predicateArgsInOrder(graph->getNextStateVersion(target)), rawState);
+            PTRef newState = TimeMachine(logic).sendFlaThroughTime(rawSimplified, -1);
+            Entry entry {target, newState};
+            auto insertionResult = nodes.tryInsert(entry);
+            switch (insertionResult) {
+                case InsertionResult::NEW: {
+                    // TODO: Lightweight feasibility check?
+                    q.push_back(entry);
+                    break;
+                }
+                case InsertionResult::DUPLICATE: {
+                    // Already known state, ignore
+                    break;
+                }
+            }
+        }
+    }
+    return VerificationResult{VerificationAnswer::SAFE};
+}
+
+
+VerificationResult SymbolicExecution::solve(ChcDirectedHyperGraph const & graph) {
+    if (graph.isNormalGraph()) {
+        return DirectForwardSymbolicExecution(graph.toNormalGraph()).run();
+    }
+    return VerificationResult{VerificationAnswer::UNKNOWN};
+}
+} // namespace golem

--- a/src/engine/SymbolicExecution.cc
+++ b/src/engine/SymbolicExecution.cc
@@ -9,23 +9,64 @@
 #include "graph/ChcGraph.h"
 #include "utils/SmtSolver.h"
 
+#include <algorithm>
+
 namespace golem {
+
+namespace {
+
+struct State {
+    using id_t = std::size_t;
+    SymRef node;
+    PTRef state;
+    id_t id;
+};
+
+struct Predecessors {
+    std::vector<State> states;
+    std::unordered_map<State::id_t, std::pair<State::id_t, EId>> predecessors;
+
+    void add(State const & successor, State::id_t predecessorId, EId edge) {
+        assert(successor.id == states.size());
+        states.push_back(successor);
+        assert(not predecessors.contains(successor.id));
+        predecessors.insert({successor.id, {predecessorId, edge}});
+    }
+};
 
 class DirectForwardSymbolicExecution {
 public:
-    explicit DirectForwardSymbolicExecution(std::unique_ptr<ChcDirectedGraph> graph) : graph(std::move(graph)) {}
+    explicit DirectForwardSymbolicExecution(std::unique_ptr<ChcDirectedGraph> graph, Options const & options)
+    : graph(std::move(graph)), options(options) {}
     VerificationResult run();
 private:
+    [[nodiscard]] bool computeWitness() const { return options.getOrDefault(Options::COMPUTE_WITNESS, "false") == "true"; }
+
+    [[nodiscard]] InvalidityWitness getInvalidityWitness(EId errorEid, State::id_t errorPredecessorId, Predecessors const & predecessors) const;
+
     std::unique_ptr<ChcDirectedGraph> graph;
+    Options const & options;
 };
+
+InvalidityWitness DirectForwardSymbolicExecution::getInvalidityWitness(EId errorEid, State::id_t errorPredecessorId, Predecessors const & predecessors) const {
+    std::vector<EId> errorPath {errorEid};
+    State::id_t currentId = errorPredecessorId;
+    while (true) {
+        State const & state = predecessors.states.at(currentId);
+        assert(state.id == currentId);
+        if (state.node == graph->getEntry()) { break; }
+        auto const & [predecessorId, edge] = predecessors.predecessors.at(currentId);
+        errorPath.push_back(edge);
+        currentId = predecessorId;
+    }
+    std::ranges::reverse(errorPath);
+    ErrorPath const path{std::move(errorPath)};
+    return InvalidityWitness::fromErrorPath(path, *graph);
+}
 
 VerificationResult DirectForwardSymbolicExecution::run() {
     enum class InsertionResult { NEW, DUPLICATE };
-    using Entry = std::pair<SymRef, PTRef>;
     struct DiscoveredArgNodes {
-        InsertionResult tryInsert(Entry const & entry) {
-            return tryInsert(entry.first, entry.second);
-        }
         InsertionResult tryInsert(SymRef node, PTRef state) {
             const auto [_, inserted] = nodes[node].insert(state);
             return inserted ? InsertionResult::NEW : InsertionResult::DUPLICATE;
@@ -33,41 +74,51 @@ VerificationResult DirectForwardSymbolicExecution::run() {
     private:
         std::unordered_map<SymRef, std::unordered_set<PTRef, PTRefHash>, SymRefHash> nodes;
     };
-    using Queue = std::deque<Entry>;
+    using Queue = std::deque<State>;
     Queue q;
     DiscoveredArgNodes nodes;
+    Predecessors predecessors;
     Logic & logic = graph->getLogic();
     AdjacencyListsGraphRepresentation ar = AdjacencyListsGraphRepresentation::from(*graph);
     TermUtils utils(logic);
+    State::id_t nextId = 0u;
 
-    q.emplace_back(graph->getEntry(), logic.getTerm_true());
-    nodes.tryInsert(q.back());
+    State entry {graph->getEntry(), logic.getTerm_true(), nextId++};
+    q.emplace_back(entry);
+    nodes.tryInsert(entry.node, entry.state);
+    predecessors.states.push_back(entry);
     while (not q.empty()) {
-        auto [node, state] = q.front();
+        State currentState = q.front();
         q.pop_front();
-        for (EId eid : ar.getOutgoingEdgesFor(node)) {
+        for (EId eid : ar.getOutgoingEdgesFor(currentState.node)) {
             auto target = graph->getTarget(eid);
             PTRef label = graph->getEdgeLabel(eid);
             if (target == graph->getExit()) {
                 SMTSolver solver{logic, SMTSolver::WitnessProduction::NONE};
-                solver.assertProp(state);
+                solver.assertProp(currentState.state);
                 solver.assertProp(label);
                 auto res = solver.check();
-                if (res == SMTSolver::Answer::SAT) { return VerificationResult{VerificationAnswer::UNSAFE}; }
+                if (res == SMTSolver::Answer::SAT) {
+                    if (computeWitness()) { return VerificationResult{VerificationAnswer::UNSAFE, getInvalidityWitness(eid, currentState.id, predecessors)}; }
+                    return VerificationResult{VerificationAnswer::UNSAFE};
+                }
                 if (res != SMTSolver::Answer::UNSAT) { return VerificationResult{VerificationAnswer::UNKNOWN}; }
                 continue;
             }
-            PTRef rawState = utils.simplifyMax(logic.mkAnd(state, label));
+            PTRef rawState = utils.simplifyMax(logic.mkAnd(currentState.state, label));
 
             PTRef rawSimplified = TrivialQuantifierElimination(logic).tryEliminateVarsExcept(
                 TermUtils(logic).predicateArgsInOrder(graph->getNextStateVersion(target)), rawState);
             PTRef newState = TimeMachine(logic).sendFlaThroughTime(rawSimplified, -1);
-            Entry entry {target, newState};
-            auto insertionResult = nodes.tryInsert(entry);
+            auto insertionResult = nodes.tryInsert(target, newState);
             switch (insertionResult) {
                 case InsertionResult::NEW: {
                     // TODO: Lightweight feasibility check?
-                    q.push_back(entry);
+                    State nextState {target, newState, nextId++};
+                    if (computeWitness()) {
+                        predecessors.add(nextState, currentState.id, eid);
+                    }
+                    q.push_back(nextState);
                     break;
                 }
                 case InsertionResult::DUPLICATE: {
@@ -80,10 +131,13 @@ VerificationResult DirectForwardSymbolicExecution::run() {
     return VerificationResult{VerificationAnswer::SAFE};
 }
 
+} // namespace
+
+
 
 VerificationResult SymbolicExecution::solve(ChcDirectedHyperGraph const & graph) {
     if (graph.isNormalGraph()) {
-        return DirectForwardSymbolicExecution(graph.toNormalGraph()).run();
+        return DirectForwardSymbolicExecution(graph.toNormalGraph(), options).run();
     }
     return VerificationResult{VerificationAnswer::UNKNOWN};
 }

--- a/src/engine/SymbolicExecution.h
+++ b/src/engine/SymbolicExecution.h
@@ -21,5 +21,4 @@ public:
 };
 } // namespace golem
 
-
 #endif // GOLEM_SYMBOLICEXECUTION_H

--- a/src/engine/SymbolicExecution.h
+++ b/src/engine/SymbolicExecution.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef GOLEM_SYMBOLICEXECUTION_H
+#define GOLEM_SYMBOLICEXECUTION_H
+
+#include "Engine.h"
+#include "Options.h"
+
+namespace golem {
+class SymbolicExecution : public Engine {
+    Options const & options;
+
+public:
+    SymbolicExecution(Logic &, Options const & options) : options(options) {}
+
+    VerificationResult solve(ChcDirectedHyperGraph const & graph) override;
+};
+} // namespace golem
+
+
+#endif // GOLEM_SYMBOLICEXECUTION_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(GolemTest
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Normalizer.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_QE.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Spacer.cc"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_SymbolicExecution.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_TermUtils.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_TPA.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_TransformationUtils.cc"

--- a/test/test_SymbolicExecution.cc
+++ b/test/test_SymbolicExecution.cc
@@ -14,6 +14,7 @@ class SETest : public LIAEngineTest {
 };
 
 TEST_F(SETest, test_Simple_Unsafe) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef inv_sym = mkPredicateSymbol("Inv", {intSort()});
     PTRef inv = instantiatePredicate(inv_sym, {x});
     PTRef invp = instantiatePredicate(inv_sym, {xp});
@@ -33,7 +34,7 @@ TEST_F(SETest, test_Simple_Unsafe) {
     };
 
     SymbolicExecution engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE);
 }
 
 TEST_F(SETest, test_Simple_Safe) {
@@ -61,6 +62,7 @@ TEST_F(SETest, test_Simple_Safe) {
 
 TEST_F(SETest, test_BeyondTransitionSystem_Unsafe)
 {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort(), intSort()});
     SymRef s2 = mkPredicateSymbol("s2", {intSort(), intSort()});
     PTRef current1 = instantiatePredicate(s1, {x,y});
@@ -99,5 +101,5 @@ TEST_F(SETest, test_BeyondTransitionSystem_Unsafe)
             ChcBody{{logic->mkAnd(logic->mkGt(y, zero), logic->mkEq(x, logic->mkIntConst(10)))}, {UninterpretedPredicate{current1}}}
         }};
     SymbolicExecution engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE);
 }

--- a/test/test_SymbolicExecution.cc
+++ b/test/test_SymbolicExecution.cc
@@ -38,6 +38,7 @@ TEST_F(SETest, test_Simple_Unsafe) {
 }
 
 TEST_F(SETest, test_Simple_Safe) {
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef inv_sym = mkPredicateSymbol("Inv", {intSort(), intSort()});
     PTRef inv = instantiatePredicate(inv_sym, {x, y});
     PTRef invp = instantiatePredicate(inv_sym, {xp, yp});
@@ -57,7 +58,7 @@ TEST_F(SETest, test_Simple_Safe) {
     };
 
     SymbolicExecution engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE);
 }
 
 TEST_F(SETest, test_BeyondTransitionSystem_Unsafe)

--- a/test/test_SymbolicExecution.cc
+++ b/test/test_SymbolicExecution.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025, Martin Blicha <martin.blicha@gmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "TestTemplate.h"
+#include "Validator.h"
+#include "engine/SymbolicExecution.h"
+#include "graph/ChcGraphBuilder.h"
+#include <gtest/gtest.h>
+
+class SETest : public LIAEngineTest {
+};
+
+TEST_F(SETest, test_Simple_Unsafe) {
+    SymRef inv_sym = mkPredicateSymbol("Inv", {intSort()});
+    PTRef inv = instantiatePredicate(inv_sym, {x});
+    PTRef invp = instantiatePredicate(inv_sym, {xp});
+    std::vector<ChClause> clauses{
+        { // x' = 0 => Inv(x')
+            ChcHead{UninterpretedPredicate{invp}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        { // Inv(x) & x' = x + 1 => Inv(x')
+            ChcHead{UninterpretedPredicate{invp}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))}, {UninterpretedPredicate{inv}}}
+        },
+        { // Inv(x) & x > 1 => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGt(x, one)}, {UninterpretedPredicate{inv}}}
+        }
+    };
+
+    SymbolicExecution engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+}
+
+TEST_F(SETest, test_Simple_Safe) {
+    SymRef inv_sym = mkPredicateSymbol("Inv", {intSort(), intSort()});
+    PTRef inv = instantiatePredicate(inv_sym, {x, y});
+    PTRef invp = instantiatePredicate(inv_sym, {xp, yp});
+    std::vector<ChClause> clauses{
+        { // x' = y' => Inv(x', y')
+            ChcHead{UninterpretedPredicate{invp}},
+            ChcBody{{logic->mkEq(xp, yp)}, {}}
+        },
+        { // Inv(x,y) and x' = x + 1 and y' = y + 1 => Inv(x', y')
+            ChcHead{UninterpretedPredicate{invp}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, logic->mkPlus(x, one)), logic->mkEq(yp, logic->mkPlus(y, one)))}, {UninterpretedPredicate{inv}}}
+        },
+        { // Inv(x, y) and x != y => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkNot(logic->mkEq(x, y))}, {UninterpretedPredicate{inv}}}
+        }
+    };
+
+    SymbolicExecution engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+}
+
+TEST_F(SETest, test_BeyondTransitionSystem_Unsafe)
+{
+    SymRef s1 = mkPredicateSymbol("s1", {intSort(), intSort()});
+    SymRef s2 = mkPredicateSymbol("s2", {intSort(), intSort()});
+    PTRef current1 = instantiatePredicate(s1, {x,y});
+    PTRef next1 = instantiatePredicate(s1, {xp,yp});
+    PTRef current2 = instantiatePredicate(s2, {x,y});
+    PTRef next2 = instantiatePredicate(s2, {xp,yp});
+    // x = 0 and y = 0 => S1(x,y)
+    // S1(x,y) and x' = x + 1 => S1(x',y)
+    // S1(x,y) and x > 5 => S2(x,y)
+    // S2(x,y) and y' = y + 1 => S2(x,y')
+    // S2(x,y) and y > 5 => S1(x,y)
+    // S1(x,y) and y > 0 and x = 10 => false
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next1}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, zero), logic->mkEq(yp, zero))}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next1}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, logic->mkPlus(x, one)), logic->mkEq(yp, y))}, {UninterpretedPredicate{current1}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{current2}},
+            ChcBody{{logic->mkGt(x, logic->mkIntConst(5))}, {UninterpretedPredicate{current1}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next2}},
+            ChcBody{{logic->mkAnd(logic->mkEq(yp, logic->mkPlus(y, one)), logic->mkEq(xp, x))}, {UninterpretedPredicate{current2}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{current1}},
+            ChcBody{{logic->mkGt(y, logic->mkIntConst(5))}, {UninterpretedPredicate{current2}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkAnd(logic->mkGt(y, zero), logic->mkEq(x, logic->mkIntConst(10)))}, {UninterpretedPredicate{current1}}}
+        }};
+    SymbolicExecution engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+}


### PR DESCRIPTION
Based on [this paper](https://link.springer.com/chapter/10.1007/978-3-031-50524-9_13), we implement a *forward* exploration of the reachability graph by representing the reachable states precisely by their path formula.
To keep the formula compact and increase the chance of identifying same states, we apply light-weight quantifier elimination to the (implicitly existentially quantified) non-current-states variables.

SAT witnesses are computed the same way as in predicate abstraction: we need to disjoin all discovered states associated with the given predicate. However, note that we need to compute representation only over current state variables, so we need to apply full quantifier elimination here.

For UNSAT witness, we need to be able to reconstruct the path for the given node in reachability graph.

This is a first prototype and works only for linear CHC systems, because there the implementation is much simpler.
Implementation for nonlinear systems will have to resemble the predicate abstraction implementation much closer.

We can also try to detect unsatisfiability of path conditions (ideally in some light-weight manner).
For SAT witnesses, we can possibly try to replace full quantifier elimination with interpolation.