### PR TITLE
PA: Check entailment of a set of formulas one by one

### DIFF
--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -841,7 +841,7 @@ vec<PTRef> ARG::computePropagatedPredicates(C const & candidates, std::vector<No
         PTRef versionedPredicate = versionManager.baseFormulaToTarget(candidate);
         candidatesVec.push(versionedPredicate);
     }
-    auto impliedPredicates = impliedBy(std::move(candidatesVec), assertions, logic);
+    auto impliedPredicates = checkEntailmentOneByOne(std::move(candidatesVec), assertions, logic);
     for (PTRef & predicate : impliedPredicates) {
         predicate = versionManager.targetFormulaToBase(predicate);
     }

--- a/src/utils/SmtSolver.h
+++ b/src/utils/SmtSolver.h
@@ -46,6 +46,9 @@ public:
 using Formulas = vec<PTRef>;
 Formulas impliedBy(Formulas candidates, PTRef assertion, Logic & logic);
 Formulas impliedBy(Formulas candidates, vec<PTRef> const & assertions, Logic & logic);
+
+Formulas checkEntailmentOneByOne(Formulas candidates, PTRef assertion, Logic & logic);
+Formulas checkEntailmentOneByOne(Formulas candidates, vec<PTRef> const & assertions, Logic & logic);
 } // namespace golem
 
 #endif // GOLEM_SMTSOLVER_H


### PR DESCRIPTION
This was the strategy some time ago, but then it was changed between versions 0.6.4 and 0.6.5, to unify it with the strategy used in Spacer. However, it seems this strategy has negative effect on the performance of PA on LRA-TS benchmarks.
We will need to search for the best strategy here, but for now we revert to the previous implementation of the entailment check in PA.

Quick check shows that this is better for LRA-TS, but also for LIA and LIA-Lin benchmarks from 2024 (although some benchmarks exhibit slowdown, the overall effect of this change is positive).

Fixes #130.
