### PR TITLE
Graph: Add helper to get properly versioned source terms

### DIFF
--- a/src/TermUtils.h
+++ b/src/TermUtils.h
@@ -456,11 +456,11 @@ public:
     PTRef getSourceTermFor(SymRef sym, unsigned instanceCount = 0) const;
 
     class CountingProxy {
-        NonlinearCanonicalPredicateRepresentation & parent;
+        NonlinearCanonicalPredicateRepresentation const & parent;
         std::unordered_map<SymRef, unsigned, SymRefHash> counts;
 
     public:
-        CountingProxy(NonlinearCanonicalPredicateRepresentation & parent) : parent(parent) {}
+        explicit CountingProxy(NonlinearCanonicalPredicateRepresentation const & parent) : parent(parent) {}
 
         PTRef getSourceTermFor(SymRef sym) {
             auto count = counts[sym]++;
@@ -468,7 +468,7 @@ public:
         }
     };
 
-    CountingProxy createCountingProxy() { return CountingProxy(*this); }
+    CountingProxy createCountingProxy() const { return CountingProxy(*this); }
 };
 
 class TrivialQuantifierElimination {

--- a/src/engine/ArgBasedEngine.cc
+++ b/src/engine/ArgBasedEngine.cc
@@ -227,7 +227,7 @@ private:
     std::map<NodeId, PTRef> nodeToSymbolInstance;
     NodeId rootId{0};
 
-    explicit InterpolationTree() {}
+    explicit InterpolationTree() = default;
 
     NodeId createNode(NodeId parent, EId clauseId) {
         Node node{.id = nodes.size(), .parent = parent, .children = {}, .label = PTRef_Undef, .clauseId = clauseId};
@@ -683,10 +683,7 @@ public:
                     predicateVars.push(var);
                 }
             }
-            // TODO: Implement a helper to iterate over source vertices together with instantiation counter
-            std::unordered_map<SymRef, std::size_t, SymRefHash> instanceCounter;
-            for (auto source : edge.from) {
-                PTRef sourcePredicate = graph->getStateVersion(source, instanceCounter[source]++);
+            for (PTRef const sourcePredicate : graph->getSourceTerms(edge.id)) {
                 for (PTRef var : utils.predicateArgsInOrder(sourcePredicate)) {
                     assert(logic.isVar(var));
                     predicateVars.push(var);

--- a/src/graph/ChcGraph.h
+++ b/src/graph/ChcGraph.h
@@ -283,8 +283,9 @@ public:
     PTRef getEdgeLabel(EId eid) const { return getEdge(eid).fla.fla; }
 
     std::vector<SymRef> const & getSources(EId eid) const { return getEdge(eid).from; }
-
     SymRef getTarget(EId eid) const { return getEdge(eid).to; }
+    std::vector<PTRef> getSourceTerms(EId eid) const;
+
     DirectedHyperEdge contractTrivialChain(std::vector<EId> const & trivialChain);
     VertexContractionResult contractVertex(SymRef sym);
 

--- a/src/transformers/CommonUtils.cc
+++ b/src/transformers/CommonUtils.cc
@@ -153,15 +153,13 @@ InvalidityWitness::Derivation expandStepWithHyperEdge(
     const PTRef targetPredicate = predicateRepresentation.getTargetTermFor(replacingEdge.to);
     utils.mapFromPredicate(targetPredicate, summarizedStep.derivedFact, subst);
     {
-        // TODO: Better way to compute instances correctly?
-        std::unordered_map<SymRef, std::size_t, SymRefHash> instanceCounter;
+        auto countingProxy = predicateRepresentation.createCountingProxy();
         for (auto i = 0u; i < summarizedStep.premises.size(); ++i) {
             PTRef derivedFact = derivation[summarizedStep.premises[i]].derivedFact;
             if (logic.getSymRef(derivedFact) != replacingEdge.from[i]) {
                 throw std::logic_error("Order of nodes does not match!");
             }
-            PTRef sourcePredicate = predicateRepresentation.getSourceTermFor(replacingEdge.from[i],
-                                                                             instanceCounter[replacingEdge.from[i]]++);
+            PTRef sourcePredicate = countingProxy.getSourceTermFor(replacingEdge.from[i]);
             utils.mapFromPredicate(sourcePredicate, derivedFact, subst);
         }
     }

--- a/src/transformers/ConstraintSimplifier.cc
+++ b/src/transformers/ConstraintSimplifier.cc
@@ -48,10 +48,7 @@ Transformer::TransformationResult ConstraintSimplifier::transform(std::unique_pt
         constraint = normalizer.eliminateDistincts(constraint);
 
         vec<PTRef> stateVars;
-        // TODO: Implement a helper to iterate over source vertices together with instantiation counter
-        std::unordered_map<SymRef, std::size_t, SymRefHash> instanceCounter;
-        for (auto source : edge.from) {
-            PTRef sourcePredicate = graph->getStateVersion(source, instanceCounter[source]++);
+        for (auto sourcePredicate : graph->getSourceTerms(edge.id)) {
             for (PTRef var : utils.predicateArgsInOrder(sourcePredicate)) {
                 assert(logic.isVar(var));
                 stateVars.push(var);


### PR DESCRIPTION
Previously, we were manually keeping counts for each occurence of a predicate among the sources.
This is somewhat error-prone.
We already have a mechanism to correctly version the terms of edge sources in the graph, so we just expose this functionality. Here we return a vector of the source terms.
Instead of allocating a vector, we could expose a way to iterate over the source terms an apply a given action to each.