### PR TITLE
Fix trivial quantifier elimination in the presence of arrays

### DIFF
--- a/src/TermUtils.cc
+++ b/src/TermUtils.cc
@@ -97,6 +97,7 @@ template<typename TKeep> PTRef tryEliminateVars(PTRef fla, Logic & logic, TKeep 
         }
     }
     if (substitutionsToReapply.getSize() > 0) {
+        logic.substitutionsTransitiveClosure(substitutionsToReapply);
         simplifiedFormula = Substitutor(logic, substitutionsToReapply).rewrite(simplifiedFormula);
     }
     // std::cout << logic.pp(simplifiedFormula) << std::endl;

--- a/test/test_QE.cc
+++ b/test/test_QE.cc
@@ -75,7 +75,7 @@ TEST_F(QE_RealTest, test_strictInequalities) {
 
 class TrivialQE_IntTest : public ::testing::Test {
 protected:
-    ArithLogic logic {opensmt::Logic_t::QF_LIA};
+    ArithLogic logic {opensmt::Logic_t::QF_ALIA};
     PTRef x;
     PTRef y;
     PTRef xp;
@@ -120,4 +120,15 @@ TEST_F(TrivialQE_IntTest, test_BooleanVaribles) {
     EXPECT_EQ(res1, logic.getTerm_true());
     PTRef res2 = TrivialQuantifierElimination(logic).tryEliminateVarsExcept(vec{b2}, fla);
     EXPECT_EQ(res2, logic.getTerm_true());
+}
+
+TEST_F(TrivialQE_IntTest, test_ShiftedVarAndArrayAccess) {
+    SRef const arraySort = logic.getArraySort(logic.getSort_int(), logic.getSort_int());
+    PTRef const s1 = logic.mkVar(arraySort, "s1");
+    PTRef const s2 = logic.mkIntVar("s2");
+    PTRef const a1 = logic.mkIntVar("a1");
+    PTRef const a2 = logic.mkIntVar("a2");
+    PTRef const fla = logic.mkAnd({logic.mkEq(a1,a2), logic.mkEq(logic.mkPlus(s2, one), a1), logic.mkEq(logic.mkSelect({s1, a2}), one)});
+    PTRef const res = TrivialQuantifierElimination(logic).tryEliminateVarsExcept(vec{s1,s2}, fla);
+    EXPECT_EQ(res, logic.mkEq(logic.mkSelect({s1, logic.mkPlus(s2, one)}), one));
 }


### PR DESCRIPTION
Previously, we could have lost some information about the state variables. For example, if an array access uses an auxiliary variable that is known to be equal to a shifted state var through another auxiliary variable.
After substitutions, the constraint is simplified to true, so all the information is in the substitutions.
Suppose we have these substitutions:
s1[a2] -> 1
a2 -> a1
s2 -> a1 - 1

When we try to eliminate auxiliary variables a1 and a2, we figure out that we can ignore a2, and we can eliminate a1 by reversing the last substitution to a1 -> s2 + 1.
However, at the end, we have to bring back the equality s1[a2] = 1. Since we brought a2 back, we have to re-apply the substitutions. But note that just re-applying the original substitutions does not work, since we would replace a2 with a1, but lose the information about the state variable s2. In order to make we do not lose any constraints on the state variables, which are on the RHS of substitutions, we have to apply transitive closure to make sure we replace any auxiliary variables brought back with the state variables, if they are connected.