### PR TITLE
Validator: Definitions in model should not contain auxiliary variables

### DIFF
--- a/src/TransitionSystem.cc
+++ b/src/TransitionSystem.cc
@@ -9,6 +9,7 @@
 #include "QuantifierElimination.h"
 #include "TermUtils.h"
 #include "utils/SmtSolver.h"
+#include "utils/StdUtils.h"
 #include "utils/Timer.h"
 
 namespace golem {
@@ -82,13 +83,6 @@ SystemType::SystemType(vec<PTRef> const & stateVars, vec<PTRef> const & auxiliar
     std::ranges::copy(stateVars, std::back_inserter(this->stateVars));
     std::ranges::copy(auxiliaryVars, std::back_inserter(this->auxiliaryVars));
 }
-
-namespace {
-using namespace std;
-bool isSubsetOf(auto const & subset, auto const & superset) {
-    return ranges::all_of(subset, [&](PTRef elem) { return ranges::find(superset, elem) != end(superset); });
-}
-} // namespace
 
 bool SystemType::isStateFormula(PTRef fla) const {
     std::vector<PTRef> allowedVars = stateVars;

--- a/src/utils/StdUtils.h
+++ b/src/utils/StdUtils.h
@@ -7,6 +7,7 @@
 #ifndef GOLEM_STDUTILS_H
 #define GOLEM_STDUTILS_H
 
+#include <algorithm>
 #include <optional>
 
 namespace golem {
@@ -15,6 +16,11 @@ std::optional<typename MapT::mapped_type> tryGetValue(MapT const & map, typename
     auto it = map.find(key);
     return it == map.end() ? std::nullopt : std::optional<typename MapT::mapped_type>{it->second};
 }
+
+bool isSubsetOf(auto const & subset, auto const & superset) {
+    return std::ranges::all_of(subset, [&](PTRef elem) { return std::ranges::find(superset, elem) != end(superset); });
+}
+
 } // namespace golem
 
 #endif // GOLEM_STDUTILS_H


### PR DESCRIPTION
Previously, a bug that led to auxiliary variables present in the definitions went unnoticed.
Such models could even pass the logical validity tests, but will be rejected by external validation.
It also points to a possible problem, because the engine might not be handling auxiliary variables correctly.