### PR TITLE
Engines: Fix dealing with auxiliary variables in transition systems

### DIFF
--- a/src/TransformationUtils.cc
+++ b/src/TransformationUtils.cc
@@ -126,6 +126,21 @@ std::unique_ptr<TransitionSystem> ensureNoAuxiliaryVariablesInInitAndQuery(std::
     return std::make_unique<TransitionSystem>(logic, std::move(stateType), newInit, ts->getTransition(), newQuery);
 }
 
+std::unique_ptr<TransitionSystem> ensureNoAuxiliaryVariablesInQuery(std::unique_ptr<TransitionSystem> ts) {
+    auto auxVars = ts->getAuxiliaryVars();
+    if (auxVars.empty()) { return ts; }
+    Logic & logic = ts->getLogic();
+    auto auxInQuery = opensmt::matchingSubTerms(ts->getLogic(), ts->getQuery(), [&](PTRef subterm) {
+        return logic.isVar(subterm) and std::find(auxVars.begin(), auxVars.end(), subterm) != auxVars.end();
+    });
+    PTRef newQuery = ts->getQuery();
+    if (auxInQuery.size() > 0) { newQuery = QuantifierElimination(logic).eliminate(newQuery, auxInQuery); }
+    if (newQuery == ts->getQuery()) { return ts; }
+    auto stateType = std::make_unique<SystemType>(ts->getStateVars(), auxVars, logic);
+    return std::make_unique<TransitionSystem>(logic, std::move(stateType), ts->getInit(), ts->getTransition(),
+                                              newQuery);
+}
+
 namespace {
 // This function follows a Tarjan's strongly connected component detection algorithm:
 // https://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm

--- a/src/TransformationUtils.h
+++ b/src/TransformationUtils.h
@@ -24,6 +24,8 @@ std::unique_ptr<TransitionSystem> toTransitionSystem(ChcDirectedGraph const & gr
 
 std::unique_ptr<TransitionSystem> ensureNoAuxiliaryVariablesInInitAndQuery(std::unique_ptr<TransitionSystem> ts);
 
+std::unique_ptr<TransitionSystem> ensureNoAuxiliaryVariablesInQuery(std::unique_ptr<TransitionSystem> ts);
+
 struct EdgeVariables {
     std::vector<PTRef> stateVars;
     std::vector<PTRef> nextStateVars;

--- a/src/engine/PDKind.cc
+++ b/src/engine/PDKind.cc
@@ -10,6 +10,7 @@
 #include "Common.h"
 #include "ModelBasedProjection.h"
 #include "TermUtils.h"
+#include "TransformationUtils.h"
 #include "utils/ScopeGuard.h"
 #include "utils/SmtSolver.h"
 
@@ -178,6 +179,10 @@ private:
 TransitionSystemVerificationResult PDKind::solve(TransitionSystem const & system) {
     if (logic.hasArrays()) { return TransitionSystemVerificationResult{VerificationAnswer::UNKNOWN, 0u}; }
     return Context(logic, computeWitness).solve(system);
+}
+
+std::unique_ptr<TransitionSystem> PDKind::dealWithAuxiliaryVariables(std::unique_ptr<TransitionSystem> ts) {
+    return ensureNoAuxiliaryVariablesInQuery(std::move(ts));
 }
 
 TransitionSystemVerificationResult Context::solve(TransitionSystem const & system) {

--- a/src/engine/PDKind.h
+++ b/src/engine/PDKind.h
@@ -31,6 +31,7 @@ public:
 
 private:
     [[nodiscard]] TransitionSystemVerificationResult solve(TransitionSystem const & system) override;
+    std::unique_ptr<TransitionSystem> dealWithAuxiliaryVariables(std::unique_ptr<TransitionSystem>) override;
 };
 } // namespace golem
 

--- a/src/engine/TransitionSystemEngine.cc
+++ b/src/engine/TransitionSystemEngine.cc
@@ -32,6 +32,7 @@ VerificationResult TransitionSystemEngine::solve(ChcDirectedGraph const & graph)
     }
     if (isTransitionSystem(graph)) {
         auto ts = toTransitionSystem(graph);
+        ts = dealWithAuxiliaryVariables(std::move(ts));
         auto res = solve(*ts);
         return computeWitness ? translateTransitionSystemResult(res, graph, *ts) : VerificationResult(res.answer);
     }
@@ -45,5 +46,10 @@ VerificationResult TransitionSystemEngine::solve(ChcDirectedGraph const & graph)
 TransitionSystemVerificationResult TransitionSystemEngine::solve(TransitionSystem const &) {
     return {VerificationAnswer::UNKNOWN, {0u}};
 }
+
+std::unique_ptr<TransitionSystem> TransitionSystemEngine::dealWithAuxiliaryVariables(std::unique_ptr<TransitionSystem> ts) {
+    return ensureNoAuxiliaryVariablesInInitAndQuery(std::move(ts));
+}
+
 } // namespace golem
 

--- a/src/engine/TransitionSystemEngine.h
+++ b/src/engine/TransitionSystemEngine.h
@@ -17,6 +17,7 @@ public:
     virtual TransitionSystemVerificationResult solve(TransitionSystem const &);
 
 protected:
+    virtual std::unique_ptr<TransitionSystem> dealWithAuxiliaryVariables(std::unique_ptr<TransitionSystem>);
     bool computeWitness{false};
 };
 } // namespace golem


### PR DESCRIPTION
After we allowed auxiliary variables in init and query, we encountered auxiliary variables present in the definitions of predicates in the model. Such variables would have to be existentially quantified for the model to be correct, but we don't support that.
In any case, the question whether or not an algorith can handle auxiliary variables in init adn query is more complicated than it originally seemed. For that reason we now mostly revert the implemented change. We still allow auxiliary variables in the *definition* of transition system, but the engines still eliminate them from init and query.  For PDKIND, I believe auxiliary variables in init are OK, so we only eliminate them from the query. For other engines, the question needs to be revisited later.