### PR TITLE
Termination: Parse 0-ary locations correctly

### DIFF
--- a/src/termination/Frontend.cc
+++ b/src/termination/Frontend.cc
@@ -262,6 +262,8 @@ LocationDeclaration ITS::parseFun(SExpression const & expr) {
 }
 
 Location ITS::parseLocationInstance(SExpression const & expr) {
+    if (isAtom(expr)) return {asAtom(expr), {}};
+
     auto const & args = asSubExpressions(expr);
     if (args.empty()) throw std::runtime_error("Location instance cannot be empty");
 


### PR DESCRIPTION
Previously, we assumed that all terms are given as tuples. However, we should allow 0-ary terms to be just atoms, instead of 1-tuples.