### PR TITLE
K- to 1-inductive invariant with sequence interpolants

### DIFF
--- a/src/TransitionSystem.h
+++ b/src/TransitionSystem.h
@@ -77,15 +77,16 @@ private:
 };
 
 struct KTo1Inductive {
-    enum class Mode { UNFOLD, QE };
+    enum class Mode { UNFOLD_SINGLE_QUERY, UNFOLD_HALVING, QE };
     explicit KTo1Inductive(Mode mode) : mode(mode) {}
-    [[nodiscard]] PTRef kinductiveToInductive(PTRef invariant, unsigned k, TransitionSystem const & system) const;
+    [[nodiscard]] PTRef run(PTRef invariant, unsigned k, TransitionSystem const & system) const;
 
 private:
     Mode mode;
 
     [[nodiscard]] static PTRef qe(PTRef invariant, unsigned k, TransitionSystem const & system);
-    [[nodiscard]] static PTRef unfold(PTRef invariant, unsigned k, TransitionSystem const & system);
+    [[nodiscard]] static PTRef unfoldHalving(PTRef invariant, unsigned k, TransitionSystem const & system);
+    [[nodiscard]] static PTRef unfoldSingleQuery(PTRef invariant, unsigned k, TransitionSystem const & system);
 };
 
 PTRef kinductiveToInductive(PTRef invariant, unsigned k, TransitionSystem const & system);


### PR DESCRIPTION
Based on the advice of Prof. McMillan, the computation of 1-inductive invariant can be done with a single query using sequence interpolants. Compared to the previous approach, we need fewer queries (1 vs log k), but we compute more interpolants (k vs log k).
In general the new approach is significantly faster, but there are some cases where the validation of the resulting 1-inductive invariant is slower.

It would be interesting to compare translation + validation time of both approaches.