### PR TITLE
TPA: Fix engine reset

### DIFF
--- a/src/engine/TPA.cc
+++ b/src/engine/TPA.cc
@@ -256,9 +256,14 @@ public:
 };
 
 TPASplit::~TPASplit() {
+    clearReachabilitySolvers();
+}
+
+void TPASplit::clearReachabilitySolvers() {
     for (SolverWrapper * solver : reachabilitySolvers) {
         delete solver;
     }
+    reachabilitySolvers.clear(true);
 }
 
 PTRef TPABase::getInit() const {
@@ -841,6 +846,7 @@ PTRef TPABase::refineTwoStepTarget(PTRef start, PTRef twoSteptransition, PTRef g
 void TPASplit::resetPowers() {
     this->exactPowers.clear();
     this->lessThanPowers.clear();
+    this->clearReachabilitySolvers();
     storeExactPower(0, transition); // ATr^{=0} = Tr
     lessThanPowers.push(identity);  // Atr^{<0} = Id
 }
@@ -1170,9 +1176,14 @@ bool TPABase::verifyKinductiveInvariant(PTRef fla, unsigned long k) const {
 
 // Single hierarchy version:
 TPABasic::~TPABasic() {
+    clearReachabilitySolvers();
+}
+
+void TPABasic::clearReachabilitySolvers() {
     for (SolverWrapper * solver : reachabilitySolvers) {
         delete solver;
     }
+    reachabilitySolvers.clear(true);
 }
 
 PTRef TPABasic::getLevelTransition(unsigned short power) const {
@@ -1328,6 +1339,7 @@ TPABasic::QueryResult TPABasic::reachabilityQuery(PTRef from, PTRef to, unsigned
 
 void TPABasic::resetPowers() {
     this->transitionHierarchy.clear();
+    this->clearReachabilitySolvers();
     storeLevelTransition(0, logic.mkOr(identity, transition));
 }
 

--- a/src/engine/TPA.h
+++ b/src/engine/TPA.h
@@ -242,6 +242,8 @@ private:
     bool verifyExactPower(unsigned short power) const;
 
     bool checkExactFixedPoint(unsigned short power);
+
+    void clearReachabilitySolvers();
 };
 
 class TPABasic : public TPABase {
@@ -271,6 +273,8 @@ private:
     QueryResult reachabilityQuery(PTRef from, PTRef to, unsigned short power);
 
     bool verifyPower(unsigned short level) const;
+
+    void clearReachabilitySolvers();
 };
 } // namespace golem
 


### PR DESCRIPTION
TPA engine has a method to reset it to solve a new transition system. However, this has never been used before in an incremental way. It actually did not clear the engine completely, it kept around the reachability solvers. Thus, trying to reset it with a new transition system did not work correctly, because the reachability solvers were kept from previous use.

Here we make sure the solvers are also cleared on a reset.

Fixes #148.