### PR TITLE
Fix access out of bounds in `toTransitionSystem`

### DIFF
--- a/src/TransformationUtils.cc
+++ b/src/TransformationUtils.cc
@@ -85,7 +85,7 @@ std::unique_ptr<TransitionSystem> toTransitionSystem(ChcDirectedGraph const & gr
         auto target = edge.to;
         bool isInit = source == vertices[0] && target == vertices[1];
         bool isLoop = source == vertices[1] && target == vertices[1];
-        bool isEnd = source == vertices[1] && target == vertices[2];
+        bool isEnd = vertices.size() == 3 && source == vertices[1] && target == vertices[2];
         assert(isInit || isLoop || isEnd);
         PTRef fla = edge.fla.fla;
         TermUtils utils(logic);


### PR DESCRIPTION
Anna detected a bug, which was appearing in the debug mode run on the Linux Endeavour, with both gcc and clang compilers.
The problem is, that when `toTransitionSystem` is called for Termination problem, it does not have 3 vertices, just 2.
Therefore checking `target == vertices[2]` is undefined behaviour.