### PR TITLE
added ic3ia engine to golem for transition systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ The following are available:
 
 - `--ic3ia.unsat-core-generalization` (default: `true`): when dropping literals from a bad cube, use an unsat core query to identify a minimal subset to keep, rather than dropping them one by one with separate queries.
 - `--ic3ia.initial-reset` (default: `true`): add a reset state and encodes the concrete init as the first transition step, to avoid starting with the initial predicates.
-- `--ic3ia.make-simple-property` (default: `false`): replace the bad formula with a single fresh predicate, so the abstract bad becomes a single literal.
 
 #### Running multiple engines in parallel
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ Works only for linear systems of Horn clauses (via transformation to a transitio
 The following are available:
 
 - `--ic3ia.unsat-core-generalization` (default: `true`): when dropping literals from a bad cube, use an unsat core query to identify a minimal subset to keep, rather than dropping them one by one with separate queries.
-- `--ic3ia.minimize-refinement-predicates` (default: `true`): after computing interpolants for a spurious counterexample, use an unsat core query to extract a smaller subset of the interpolant atoms that is sufficient for the refinement.
-- `--ic3ia.binary-refinement-interpolants` (default: `false`): use a single binary interpolant for refinement instead of a full sequence of path interpolants.
 - `--ic3ia.initial-reset` (default: `true`): add a reset state and encodes the concrete init as the first transition step, to avoid starting with the initial predicates.
+- `--ic3ia.make-simple-property` (default: `false`): replace the bad formula with a single fresh predicate, so the abstract bad becomes a single literal.
 
 #### Running multiple engines in parallel
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ Transitions that do not fall into this category are handled by transformation in
 
 [split-TPA](https://ieeexplore.ieee.org/document/10026590) is a different instantiation of the TPA paradigm and is typically more powerful than basic TPA on satisfiable (safe) CHC systems.
 
+### IC3 with Implicit Predicate Abstraction (IC3IA)
+
+IC3IA engine implements a version of the algorithm described in [this paper](https://link.springer.com/article/10.1007/s10703-016-0257-4).
+It combines IC3/PDR with a CEGAR loop over an implicit predicate abstraction: IC3 runs directly on the original transition formula extended with Boolean labels for the current predicates, rather than building a separate abstract system. When a spurious counterexample is found, new predicates are extracted via interpolation and the abstraction is refined.
+Works only for linear systems of Horn clauses (via transformation to a transition system).
+
+The following are available:
+
+- `--ic3ia.unsat-core-generalization` (default: `true`): when dropping literals from a bad cube, use an unsat core query to identify a minimal subset to keep, rather than dropping them one by one with separate queries.
+- `--ic3ia.minimize-refinement-predicates` (default: `true`): after computing interpolants for a spurious counterexample, use an unsat core query to extract a smaller subset of the interpolant atoms that is sufficient for the refinement.
+- `--ic3ia.binary-refinement-interpolants` (default: `false`): use a single binary interpolant for refinement instead of a full sequence of path interpolants.
+- `--ic3ia.initial-reset` (default: `true`): add a reset state and encodes the concrete init as the first transition step, to avoid starting with the initial predicates.
 
 #### Running multiple engines in parallel
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(golem_lib
     PRIVATE engine/Bmc.cc
     PRIVATE engine/Common.cc
     PRIVATE engine/DAR.cc
+    PRIVATE engine/IC3IA.cc
     PRIVATE engine/EngineFactory.cc
     PRIVATE engine/IMC.cc
     PRIVATE engine/Kind.cc

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -25,7 +25,6 @@ const std::string Options::VERBOSE = "verbose";
 const std::string Options::TPA_USE_QE = "tpa.use-qe";
 const std::string Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION = "ic3ia.unsat-core-generalization";
 const std::string Options::IC3IA_ADD_INITIAL_RESET = "ic3ia.initial-reset";
-const std::string Options::IC3IA_MAKE_SIMPLE_PROPERTY = "ic3ia.make-simple-property";
 const std::string Options::FORCE_TS = "force-ts";
 const std::string Options::SIMPLIFY_NESTED = "simplify-nested";
 const std::string Options::PROOF_FORMAT = "proof-format";
@@ -67,8 +66,6 @@ void printUsage() {
            "                                Use unsat-core-only cube generalization in IC3IA (default: true)\n"
            "--ic3ia.initial-reset[=bool]\n"
            "                                Add a reset state so IC3IA does not seed from the full init formula (default: true)\n"
-           "--ic3ia.make-simple-property[=bool]\n"
-           "                                Replace the bad formula with a single fresh predicate in IC3IA (default: false)\n"
            "--termination-backend <name>    Select backend algorithm for termination problems:\n"
            "                                  lasso-finder - searches for lasso in the system\n"
            "                                  nontermination-via-safety - gradually eliminates terminating traces from the system\n"
@@ -93,7 +90,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     int tpaUseQE = 0;
     int ic3iaUseUnsatCoreGeneralization = 0;
     int ic3iaAddInitialReset = 1;
-    int ic3iaMakeSimpleProperty = 0;
     int printVersion = 0;
     int forceTS = 0;
     int simplifyNested = 0;
@@ -113,7 +109,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                                     {Options::TPA_USE_QE.c_str(), optional_argument, &tpaUseQE, 1},
                                     {Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION.c_str(), optional_argument, &ic3iaUseUnsatCoreGeneralization, 1},
                                     {Options::IC3IA_ADD_INITIAL_RESET.c_str(), optional_argument, &ic3iaAddInitialReset, 1},
-                                    {Options::IC3IA_MAKE_SIMPLE_PROPERTY.c_str(), optional_argument, &ic3iaMakeSimpleProperty, 1},
                                     {Options::PROOF_FORMAT.c_str(), required_argument, nullptr, 'p'},
                                     {Options::FORCE_TS.c_str(), no_argument, &forceTS, 1},
                                     {Options::SIMPLIFY_NESTED.c_str(), no_argument, &simplifyNested, 1},
@@ -153,12 +148,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                         ic3iaAddInitialReset = 0;
                     } else {
                         ic3iaAddInitialReset = 1;
-                    }
-                } else if (long_options[option_index].flag == &ic3iaMakeSimpleProperty and optarg) {
-                    if (isDisableKeyword(optarg)) {
-                        ic3iaMakeSimpleProperty = 0;
-                    } else {
-                        ic3iaMakeSimpleProperty = 1;
                     }
                 } else if (long_options[option_index].flag == &lraItpAlg) {
                     assert(optarg);
@@ -215,7 +204,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     if (tpaUseQE) { res.addOption(Options::TPA_USE_QE, "true"); }
     res.addOption(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, ic3iaUseUnsatCoreGeneralization ? "true" : "false");
     res.addOption(Options::IC3IA_ADD_INITIAL_RESET, ic3iaAddInitialReset ? "true" : "false");
-    if (ic3iaMakeSimpleProperty) { res.addOption(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "true"); }
     if (forceTS) { res.addOption(Options::FORCE_TS, "true"); }
     if (simplifyNested) { res.addOption(Options::SIMPLIFY_NESTED, "true"); }
     res.addOption(Options::LRA_ITP_ALG, std::to_string(lraItpAlg));

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -23,6 +23,10 @@ const std::string Options::LRA_ITP_ALG = "lra-itp-algorithm";
 const std::string Options::FORCED_COVERING = "forced-covering";
 const std::string Options::VERBOSE = "verbose";
 const std::string Options::TPA_USE_QE = "tpa.use-qe";
+const std::string Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION = "ic3ia.unsat-core-generalization";
+const std::string Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES = "ic3ia.minimize-refinement-predicates";
+const std::string Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS = "ic3ia.binary-refinement-interpolants";
+const std::string Options::IC3IA_ADD_INITIAL_RESET = "ic3ia.initial-reset";
 const std::string Options::FORCE_TS = "force-ts";
 const std::string Options::SIMPLIFY_NESTED = "simplify-nested";
 const std::string Options::PROOF_FORMAT = "proof-format";
@@ -40,6 +44,7 @@ void printUsage() {
            "-e,--engine <name>              Select engine to use; supported engines:\n"
            "                                  bmc - Bounded Model Checking (only linear systems)\n"
            "                                  dar - Dual Approximated Reachability (only linear systems)\n"
+           "                                  ic3ia - IC3 with Implicit Predicate Abstraction (only linear systems)\n"
            "                                  imc - McMillan's original Interpolation-based model checking (only linear systems)\n"
            "                                  kind - basic k-induction algorithm (only transition systems)\n"
            "                                  lawi - Lazy Abstraction with Interpolants (only linear systems)\n"
@@ -59,6 +64,14 @@ void printUsage() {
            "-v                              Increase verbosity (can be applied multiple times)\n"
            "-i,--input <file>               Input file (option not required)\n"
            "--force-ts                      Always encode linear system into transition system (affects BMC and TPA)\n"
+           "--ic3ia.unsat-core-generalization[=bool]\n"
+           "                                Use unsat-core-only cube generalization in IC3IA (default: true)\n"
+           "--ic3ia.minimize-refinement-predicates[=bool]\n"
+           "                                Minimize interpolant-derived predicates after refinement in IC3IA (default: true)\n"
+           "--ic3ia.binary-refinement-interpolants[=bool]\n"
+           "                                Use binary interpolants in IC3IA refinement instead of path interpolants (default: false)\n"
+           "--ic3ia.initial-reset[=bool]\n"
+           "                                Add a reset state so IC3IA does not seed from the full init formula (default: true)\n"
            "--termination-backend <name>    Select backend algorithm for termination problems:\n"
            "                                  lasso-finder - searches for lasso in the system\n"
            "                                  nontermination-via-safety - gradually eliminates terminating traces from the system\n"
@@ -81,6 +94,10 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     int forcedCovering = 0;
     int verbose = 0;
     int tpaUseQE = 0;
+    int ic3iaUseUnsatCoreGeneralization = 0;
+    int ic3iaMinimizeRefinementPredicates = 0;
+    int ic3iaUseBinaryRefinementInterpolants = 0;
+    int ic3iaAddInitialReset = 1;
     int printVersion = 0;
     int forceTS = 0;
     int simplifyNested = 0;
@@ -98,6 +115,10 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                                     {Options::FORCED_COVERING.c_str(), optional_argument, &forcedCovering, 1},
                                     {Options::VERBOSE.c_str(), optional_argument, &verbose, 1},
                                     {Options::TPA_USE_QE.c_str(), optional_argument, &tpaUseQE, 1},
+                                    {Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION.c_str(), optional_argument, &ic3iaUseUnsatCoreGeneralization, 1},
+                                    {Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES.c_str(), optional_argument, &ic3iaMinimizeRefinementPredicates, 1},
+                                    {Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS.c_str(), optional_argument, &ic3iaUseBinaryRefinementInterpolants, 1},
+                                    {Options::IC3IA_ADD_INITIAL_RESET.c_str(), optional_argument, &ic3iaAddInitialReset, 1},
                                     {Options::PROOF_FORMAT.c_str(), required_argument, nullptr, 'p'},
                                     {Options::FORCE_TS.c_str(), no_argument, &forceTS, 1},
                                     {Options::SIMPLIFY_NESTED.c_str(), no_argument, &simplifyNested, 1},
@@ -126,6 +147,30 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                     }
                 } else if (long_options[option_index].flag == &tpaUseQE) {
                     tpaUseQE = 1;
+                } else if (long_options[option_index].flag == &ic3iaUseUnsatCoreGeneralization and optarg) {
+                    if (isDisableKeyword(optarg)) {
+                        ic3iaUseUnsatCoreGeneralization = 0;
+                    } else {
+                        ic3iaUseUnsatCoreGeneralization = 1;
+                    }
+                } else if (long_options[option_index].flag == &ic3iaMinimizeRefinementPredicates and optarg) {
+                    if (isDisableKeyword(optarg)) {
+                        ic3iaMinimizeRefinementPredicates = 0;
+                    } else {
+                        ic3iaMinimizeRefinementPredicates = 1;
+                    }
+                } else if (long_options[option_index].flag == &ic3iaUseBinaryRefinementInterpolants and optarg) {
+                    if (isDisableKeyword(optarg)) {
+                        ic3iaUseBinaryRefinementInterpolants = 0;
+                    } else {
+                        ic3iaUseBinaryRefinementInterpolants = 1;
+                    }
+                } else if (long_options[option_index].flag == &ic3iaAddInitialReset and optarg) {
+                    if (isDisableKeyword(optarg)) {
+                        ic3iaAddInitialReset = 0;
+                    } else {
+                        ic3iaAddInitialReset = 1;
+                    }
                 } else if (long_options[option_index].flag == &lraItpAlg) {
                     assert(optarg);
                     lraItpAlg = std::atoi(optarg);
@@ -179,6 +224,10 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     if (validate || computeWitness || printWitness) { res.addOption(Options::COMPUTE_WITNESS, "true"); }
     if (forcedCovering) { res.addOption(Options::FORCED_COVERING, "true"); }
     if (tpaUseQE) { res.addOption(Options::TPA_USE_QE, "true"); }
+    if (ic3iaUseUnsatCoreGeneralization) { res.addOption(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true"); }
+    if (ic3iaMinimizeRefinementPredicates) { res.addOption(Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES, "true"); }
+    if (ic3iaUseBinaryRefinementInterpolants) { res.addOption(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "true"); }
+    res.addOption(Options::IC3IA_ADD_INITIAL_RESET, ic3iaAddInitialReset ? "true" : "false");
     if (forceTS) { res.addOption(Options::FORCE_TS, "true"); }
     if (simplifyNested) { res.addOption(Options::SIMPLIFY_NESTED, "true"); }
     res.addOption(Options::LRA_ITP_ALG, std::to_string(lraItpAlg));

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -24,8 +24,6 @@ const std::string Options::FORCED_COVERING = "forced-covering";
 const std::string Options::VERBOSE = "verbose";
 const std::string Options::TPA_USE_QE = "tpa.use-qe";
 const std::string Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION = "ic3ia.unsat-core-generalization";
-const std::string Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES = "ic3ia.minimize-refinement-predicates";
-const std::string Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS = "ic3ia.binary-refinement-interpolants";
 const std::string Options::IC3IA_ADD_INITIAL_RESET = "ic3ia.initial-reset";
 const std::string Options::IC3IA_MAKE_SIMPLE_PROPERTY = "ic3ia.make-simple-property";
 const std::string Options::FORCE_TS = "force-ts";
@@ -67,10 +65,6 @@ void printUsage() {
            "--force-ts                      Always encode linear system into transition system (affects BMC and TPA)\n"
            "--ic3ia.unsat-core-generalization[=bool]\n"
            "                                Use unsat-core-only cube generalization in IC3IA (default: true)\n"
-           "--ic3ia.minimize-refinement-predicates[=bool]\n"
-           "                                Minimize interpolant-derived predicates after refinement in IC3IA (default: true)\n"
-           "--ic3ia.binary-refinement-interpolants[=bool]\n"
-           "                                Use binary interpolants in IC3IA refinement instead of path interpolants (default: false)\n"
            "--ic3ia.initial-reset[=bool]\n"
            "                                Add a reset state so IC3IA does not seed from the full init formula (default: true)\n"
            "--ic3ia.make-simple-property[=bool]\n"
@@ -98,8 +92,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     int verbose = 0;
     int tpaUseQE = 0;
     int ic3iaUseUnsatCoreGeneralization = 0;
-    int ic3iaMinimizeRefinementPredicates = 0;
-    int ic3iaUseBinaryRefinementInterpolants = 0;
     int ic3iaAddInitialReset = 1;
     int ic3iaMakeSimpleProperty = 0;
     int printVersion = 0;
@@ -120,8 +112,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                                     {Options::VERBOSE.c_str(), optional_argument, &verbose, 1},
                                     {Options::TPA_USE_QE.c_str(), optional_argument, &tpaUseQE, 1},
                                     {Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION.c_str(), optional_argument, &ic3iaUseUnsatCoreGeneralization, 1},
-                                    {Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES.c_str(), optional_argument, &ic3iaMinimizeRefinementPredicates, 1},
-                                    {Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS.c_str(), optional_argument, &ic3iaUseBinaryRefinementInterpolants, 1},
                                     {Options::IC3IA_ADD_INITIAL_RESET.c_str(), optional_argument, &ic3iaAddInitialReset, 1},
                                     {Options::IC3IA_MAKE_SIMPLE_PROPERTY.c_str(), optional_argument, &ic3iaMakeSimpleProperty, 1},
                                     {Options::PROOF_FORMAT.c_str(), required_argument, nullptr, 'p'},
@@ -157,18 +147,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                         ic3iaUseUnsatCoreGeneralization = 0;
                     } else {
                         ic3iaUseUnsatCoreGeneralization = 1;
-                    }
-                } else if (long_options[option_index].flag == &ic3iaMinimizeRefinementPredicates and optarg) {
-                    if (isDisableKeyword(optarg)) {
-                        ic3iaMinimizeRefinementPredicates = 0;
-                    } else {
-                        ic3iaMinimizeRefinementPredicates = 1;
-                    }
-                } else if (long_options[option_index].flag == &ic3iaUseBinaryRefinementInterpolants and optarg) {
-                    if (isDisableKeyword(optarg)) {
-                        ic3iaUseBinaryRefinementInterpolants = 0;
-                    } else {
-                        ic3iaUseBinaryRefinementInterpolants = 1;
                     }
                 } else if (long_options[option_index].flag == &ic3iaAddInitialReset and optarg) {
                     if (isDisableKeyword(optarg)) {
@@ -236,8 +214,6 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     if (forcedCovering) { res.addOption(Options::FORCED_COVERING, "true"); }
     if (tpaUseQE) { res.addOption(Options::TPA_USE_QE, "true"); }
     if (ic3iaUseUnsatCoreGeneralization) { res.addOption(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true"); }
-    if (ic3iaMinimizeRefinementPredicates) { res.addOption(Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES, "true"); }
-    if (ic3iaUseBinaryRefinementInterpolants) { res.addOption(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "true"); }
     res.addOption(Options::IC3IA_ADD_INITIAL_RESET, ic3iaAddInitialReset ? "true" : "false");
     if (ic3iaMakeSimpleProperty) { res.addOption(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "true"); }
     if (forceTS) { res.addOption(Options::FORCE_TS, "true"); }

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -213,7 +213,7 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     if (validate || computeWitness || printWitness) { res.addOption(Options::COMPUTE_WITNESS, "true"); }
     if (forcedCovering) { res.addOption(Options::FORCED_COVERING, "true"); }
     if (tpaUseQE) { res.addOption(Options::TPA_USE_QE, "true"); }
-    if (ic3iaUseUnsatCoreGeneralization) { res.addOption(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true"); }
+    res.addOption(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, ic3iaUseUnsatCoreGeneralization ? "true" : "false");
     res.addOption(Options::IC3IA_ADD_INITIAL_RESET, ic3iaAddInitialReset ? "true" : "false");
     if (ic3iaMakeSimpleProperty) { res.addOption(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "true"); }
     if (forceTS) { res.addOption(Options::FORCE_TS, "true"); }

--- a/src/Options.cc
+++ b/src/Options.cc
@@ -27,6 +27,7 @@ const std::string Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION = "ic3ia.unsat-co
 const std::string Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES = "ic3ia.minimize-refinement-predicates";
 const std::string Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS = "ic3ia.binary-refinement-interpolants";
 const std::string Options::IC3IA_ADD_INITIAL_RESET = "ic3ia.initial-reset";
+const std::string Options::IC3IA_MAKE_SIMPLE_PROPERTY = "ic3ia.make-simple-property";
 const std::string Options::FORCE_TS = "force-ts";
 const std::string Options::SIMPLIFY_NESTED = "simplify-nested";
 const std::string Options::PROOF_FORMAT = "proof-format";
@@ -72,6 +73,8 @@ void printUsage() {
            "                                Use binary interpolants in IC3IA refinement instead of path interpolants (default: false)\n"
            "--ic3ia.initial-reset[=bool]\n"
            "                                Add a reset state so IC3IA does not seed from the full init formula (default: true)\n"
+           "--ic3ia.make-simple-property[=bool]\n"
+           "                                Replace the bad formula with a single fresh predicate in IC3IA (default: false)\n"
            "--termination-backend <name>    Select backend algorithm for termination problems:\n"
            "                                  lasso-finder - searches for lasso in the system\n"
            "                                  nontermination-via-safety - gradually eliminates terminating traces from the system\n"
@@ -98,6 +101,7 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     int ic3iaMinimizeRefinementPredicates = 0;
     int ic3iaUseBinaryRefinementInterpolants = 0;
     int ic3iaAddInitialReset = 1;
+    int ic3iaMakeSimpleProperty = 0;
     int printVersion = 0;
     int forceTS = 0;
     int simplifyNested = 0;
@@ -119,6 +123,7 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                                     {Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES.c_str(), optional_argument, &ic3iaMinimizeRefinementPredicates, 1},
                                     {Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS.c_str(), optional_argument, &ic3iaUseBinaryRefinementInterpolants, 1},
                                     {Options::IC3IA_ADD_INITIAL_RESET.c_str(), optional_argument, &ic3iaAddInitialReset, 1},
+                                    {Options::IC3IA_MAKE_SIMPLE_PROPERTY.c_str(), optional_argument, &ic3iaMakeSimpleProperty, 1},
                                     {Options::PROOF_FORMAT.c_str(), required_argument, nullptr, 'p'},
                                     {Options::FORCE_TS.c_str(), no_argument, &forceTS, 1},
                                     {Options::SIMPLIFY_NESTED.c_str(), no_argument, &simplifyNested, 1},
@@ -170,6 +175,12 @@ Options CommandLineParser::parse(int argc, char ** argv) {
                         ic3iaAddInitialReset = 0;
                     } else {
                         ic3iaAddInitialReset = 1;
+                    }
+                } else if (long_options[option_index].flag == &ic3iaMakeSimpleProperty and optarg) {
+                    if (isDisableKeyword(optarg)) {
+                        ic3iaMakeSimpleProperty = 0;
+                    } else {
+                        ic3iaMakeSimpleProperty = 1;
                     }
                 } else if (long_options[option_index].flag == &lraItpAlg) {
                     assert(optarg);
@@ -228,6 +239,7 @@ Options CommandLineParser::parse(int argc, char ** argv) {
     if (ic3iaMinimizeRefinementPredicates) { res.addOption(Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES, "true"); }
     if (ic3iaUseBinaryRefinementInterpolants) { res.addOption(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "true"); }
     res.addOption(Options::IC3IA_ADD_INITIAL_RESET, ic3iaAddInitialReset ? "true" : "false");
+    if (ic3iaMakeSimpleProperty) { res.addOption(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "true"); }
     if (forceTS) { res.addOption(Options::FORCE_TS, "true"); }
     if (simplifyNested) { res.addOption(Options::SIMPLIFY_NESTED, "true"); }
     res.addOption(Options::LRA_ITP_ALG, std::to_string(lraItpAlg));

--- a/src/Options.h
+++ b/src/Options.h
@@ -47,7 +47,6 @@ public:
     static const std::string TPA_USE_QE;
     static const std::string IC3IA_USE_UNSAT_CORE_GENERALIZATION;
     static const std::string IC3IA_ADD_INITIAL_RESET;
-    static const std::string IC3IA_MAKE_SIMPLE_PROPERTY;
     static const std::string FORCE_TS;
     static const std::string SIMPLIFY_NESTED;
     static const std::string TERMINATION_BACKEND;

--- a/src/Options.h
+++ b/src/Options.h
@@ -49,6 +49,7 @@ public:
     static const std::string IC3IA_MINIMIZE_REFINEMENT_PREDICATES;
     static const std::string IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS;
     static const std::string IC3IA_ADD_INITIAL_RESET;
+    static const std::string IC3IA_MAKE_SIMPLE_PROPERTY;
     static const std::string FORCE_TS;
     static const std::string SIMPLIFY_NESTED;
     static const std::string TERMINATION_BACKEND;

--- a/src/Options.h
+++ b/src/Options.h
@@ -46,8 +46,6 @@ public:
     static const std::string VERBOSE;
     static const std::string TPA_USE_QE;
     static const std::string IC3IA_USE_UNSAT_CORE_GENERALIZATION;
-    static const std::string IC3IA_MINIMIZE_REFINEMENT_PREDICATES;
-    static const std::string IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS;
     static const std::string IC3IA_ADD_INITIAL_RESET;
     static const std::string IC3IA_MAKE_SIMPLE_PROPERTY;
     static const std::string FORCE_TS;

--- a/src/Options.h
+++ b/src/Options.h
@@ -45,6 +45,10 @@ public:
     static const std::string FORCED_COVERING;
     static const std::string VERBOSE;
     static const std::string TPA_USE_QE;
+    static const std::string IC3IA_USE_UNSAT_CORE_GENERALIZATION;
+    static const std::string IC3IA_MINIMIZE_REFINEMENT_PREDICATES;
+    static const std::string IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS;
+    static const std::string IC3IA_ADD_INITIAL_RESET;
     static const std::string FORCE_TS;
     static const std::string SIMPLIFY_NESTED;
     static const std::string TERMINATION_BACKEND;

--- a/src/engine/EngineFactory.cc
+++ b/src/engine/EngineFactory.cc
@@ -9,6 +9,7 @@
 #include "ArgBasedEngine.h"
 #include "Bmc.h"
 #include "DAR.h"
+#include "IC3IA.h"
 #include "IMC.h"
 #include "Kind.h"
 #include "Lawi.h"
@@ -20,7 +21,9 @@
 
 namespace golem {
 std::unique_ptr<Engine> EngineFactory::getEngine(std::string_view engine) && {
-    if (engine == "spacer") {
+    if (engine == "ic3ia") {
+        return std::make_unique<IC3IA>(logic, options);
+    } else if (engine == "spacer") {
         return std::make_unique<Spacer>(logic, options);
     } else if (engine == TPAEngine::TPA) {
         return std::make_unique<TPAEngine>(logic, options, TPACore::BASIC);

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -32,8 +32,6 @@ IC3IA::IC3IA(Logic & logic, Options const & options) : logic_(logic) {
     options.getOrDefault(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true") == "true";
     addInitialReset_ =
         options.getOrDefault(Options::IC3IA_ADD_INITIAL_RESET, "true") == "true";
-    makeSimpleProperty_ =
-        options.getOrDefault(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "false") == "true";
 }
 
 //=============================================================================
@@ -373,11 +371,6 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
     concreteStateVars_    = system.getStateVars();
     concreteNextStateVars_= system.getNextStateVars();
 
-    simplePropOrigBad_ = PTRef_Undef;
-    simplePropVar_ = PTRef_Undef;
-    if (makeSimpleProperty_) {
-        applySimpleProperty();
-    }
     if (addInitialReset_) {
         applyInitialReset();
     }
@@ -409,11 +402,6 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
                 PTRef resetVar = tm.getVarVersionZero("ic3ia_reset", logic_.getSort_bool());
                 TermUtils::substitutions_map subst;
                 subst[resetVar] = logic_.getTerm_false();
-                concreteInv = TermUtils(logic_).varSubstitute(concreteInv, subst);
-            }
-            if (makeSimpleProperty_ && simplePropVar_ != PTRef_Undef) {
-                TermUtils::substitutions_map subst;
-                subst[simplePropVar_] = simplePropOrigBad_;
                 concreteInv = TermUtils(logic_).varSubstitute(concreteInv, subst);
             }
             return {VerificationAnswer::SAFE, concreteInv};
@@ -591,34 +579,6 @@ bool IC3IA::addPredicate(PTRef pred) {
     predLabels_.push_back(lCurr);
     predLabelsNext_.push_back(lNext);
     return true;
-}
-
-void IC3IA::applySimpleProperty() {
-    // Skip if bad is already a single Boolean state var.
-    if (logic_.isVar(concreteBad_) && logic_.hasSortBool(concreteBad_)) {
-        return;
-    }
-    TimeMachine tm{logic_};
-    PTRef p     = tm.getVarVersionZero("ic3ia_simpleprop", logic_.getSort_bool());
-    PTRef pNext = tm.sendVarThroughTime(p, 1);
-
-    PTRef oldInit  = concreteInit_;
-    PTRef oldTrans = concreteTrans_;
-    PTRef oldBad   = concreteBad_;
-    PTRef badNext  = atTime(oldBad, 1);
-
-    concreteInit_  = logic_.mkAnd(oldInit, logic_.mkEq(p, oldBad));
-    concreteTrans_ = logic_.mkAnd({oldTrans, logic_.mkEq(p, oldBad), logic_.mkEq(pNext, badNext)});
-    concreteBad_   = p;
-    concreteStateVars_.push_back(p);
-    concreteNextStateVars_.push_back(pNext);
-
-    simplePropOrigBad_ = oldBad;
-    simplePropVar_     = p;
-
-    if (verbosity_ > 0) {
-        std::cout << "[IC3IA] Replaced property with single state var\n";
-    }
 }
 
 void IC3IA::applyInitialReset() {

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -14,8 +14,10 @@
 #include <cassert>
 #include <chrono>
 #include <iostream>
+#include <random>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace golem {
 
@@ -494,67 +496,81 @@ std::vector<PTRef> IC3IA::minimizeRefinementPredicateSet(std::vector<PTRef> cand
                                                          std::size_t depth) const {
     if (candidates.size() <= 1 || unshiftedInterpolants.empty()) { return candidates; }
 
-    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_UNSAT_CORE);
-    solver.assertProp(concreteInit_);
-    for (std::size_t i = 0; i < depth; ++i) {
-        solver.assertProp(atTime(concreteTrans_, static_cast<unsigned>(i)));
-    }
-    solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(depth)));
+    constexpr int maxIter = 5;
+    constexpr int maxFail = 2;
+    std::mt19937 rng(0xC0FFEEu);
+    int failures = 0;
 
-    TermUtils::substitutions_map subst;
-    std::vector<PTRef> activationLiterals;
-    std::vector<PTRef> abstractionLabels;
-    std::vector<PTRef> guardedDefinitions;
-    activationLiterals.reserve(candidates.size());
-    abstractionLabels.reserve(candidates.size());
-    guardedDefinitions.reserve(candidates.size());
+    for (int iter = 0; iter < maxIter; ++iter) {
+        if (iter > 0) { std::shuffle(candidates.begin(), candidates.end(), rng); }
 
-    for (std::size_t i = 0; i < candidates.size(); ++i) {
-        std::string suffix = std::to_string(i);
-        PTRef act = logic_.mkBoolVar((".ic3ia_refpred_act_" + suffix).c_str());
-        PTRef lbl = logic_.mkBoolVar((".ic3ia_refpred_lbl_" + suffix).c_str());
-        activationLiterals.push_back(act);
-        abstractionLabels.push_back(lbl);
-        subst[candidates[i]] = lbl;
-        subst[logic_.mkNot(candidates[i])] = logic_.mkNot(lbl);
-    }
-
-    TermUtils termUtils(logic_);
-    for (std::size_t i = 0; i < unshiftedInterpolants.size(); ++i) {
-        PTRef abstractedInterpolant = termUtils.varSubstitute(unshiftedInterpolants[i], subst);
-        solver.assertProp(atTime(abstractedInterpolant, static_cast<unsigned>(i + 1)));
-    }
-
-    for (std::size_t i = 0; i < candidates.size(); ++i) {
-        vec<PTRef> eqs;
-        for (std::size_t step = 0; step < unshiftedInterpolants.size(); ++step) {
-            eqs.push(logic_.mkEq(atTime(abstractionLabels[i], static_cast<unsigned>(step + 1)),
-                                 atTime(candidates[i], static_cast<unsigned>(step + 1))));
+        SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_UNSAT_CORE);
+        solver.assertProp(concreteInit_);
+        for (std::size_t i = 0; i < depth; ++i) {
+            solver.assertProp(atTime(concreteTrans_, static_cast<unsigned>(i)));
         }
-        PTRef definition = eqs.size() == 1 ? eqs[0] : logic_.mkAnd(eqs);
-        PTRef guarded = logic_.mkOr(logic_.mkNot(activationLiterals[i]), definition);
-        guardedDefinitions.push_back(guarded);
-        solver.assertProp(guarded);
-        solver.assertProp(activationLiterals[i]);
-    }
+        solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(depth)));
 
-    if (solver.check() != SMTSolver::Answer::UNSAT) { return candidates; }
+        TermUtils::substitutions_map subst;
+        std::vector<PTRef> activationLiterals;
+        std::vector<PTRef> abstractionLabels;
+        std::vector<PTRef> guardedDefinitions;
+        activationLiterals.reserve(candidates.size());
+        abstractionLabels.reserve(candidates.size());
+        guardedDefinitions.reserve(candidates.size());
 
-    auto core = solver.getCoreSolver().getUnsatCore();
-    std::vector<PTRef> kept;
-    kept.reserve(candidates.size());
-    for (std::size_t i = 0; i < candidates.size(); ++i) {
-        bool inCore = false;
-        for (PTRef t : core->getTerms()) {
-            if (t == activationLiterals[i] || t == guardedDefinitions[i]) {
-                inCore = true;
-                break;
+        for (std::size_t i = 0; i < candidates.size(); ++i) {
+            std::string suffix = std::to_string(i);
+            PTRef act = logic_.mkBoolVar((".ic3ia_refpred_act_" + suffix).c_str());
+            PTRef lbl = logic_.mkBoolVar((".ic3ia_refpred_lbl_" + suffix).c_str());
+            activationLiterals.push_back(act);
+            abstractionLabels.push_back(lbl);
+            subst[candidates[i]] = lbl;
+            subst[logic_.mkNot(candidates[i])] = logic_.mkNot(lbl);
+        }
+
+        TermUtils termUtils(logic_);
+        for (std::size_t i = 0; i < unshiftedInterpolants.size(); ++i) {
+            PTRef abstractedInterpolant = termUtils.varSubstitute(unshiftedInterpolants[i], subst);
+            solver.assertProp(atTime(abstractedInterpolant, static_cast<unsigned>(i + 1)));
+        }
+
+        for (std::size_t i = 0; i < candidates.size(); ++i) {
+            vec<PTRef> eqs;
+            for (std::size_t step = 0; step < unshiftedInterpolants.size(); ++step) {
+                eqs.push(logic_.mkEq(atTime(abstractionLabels[i], static_cast<unsigned>(step + 1)),
+                                     atTime(candidates[i], static_cast<unsigned>(step + 1))));
+            }
+            PTRef definition = eqs.size() == 1 ? eqs[0] : logic_.mkAnd(eqs);
+            PTRef guarded = logic_.mkOr(logic_.mkNot(activationLiterals[i]), definition);
+            guardedDefinitions.push_back(guarded);
+            solver.assertProp(guarded);
+            solver.assertProp(activationLiterals[i]);
+        }
+
+        if (solver.check() != SMTSolver::Answer::UNSAT) { return candidates; }
+
+        auto core = solver.getCoreSolver().getUnsatCore();
+        std::unordered_set<uint32_t> coreSet;
+        for (PTRef t : core->getTerms()) { coreSet.insert(t.x); }
+
+        std::vector<PTRef> kept;
+        kept.reserve(candidates.size());
+        for (std::size_t i = 0; i < candidates.size(); ++i) {
+            if (coreSet.count(activationLiterals[i].x) || coreSet.count(guardedDefinitions[i].x)) {
+                kept.push_back(candidates[i]);
             }
         }
-        if (inCore) { kept.push_back(candidates[i]); }
+
+        if (kept.empty()) { return candidates; }
+        if (kept.size() >= candidates.size()) {
+            if (++failures >= maxFail) { return candidates; }
+            continue;
+        }
+        candidates = std::move(kept);
     }
 
-    return kept.empty() ? candidates : kept;
+    return candidates;
 }
 
 bool IC3IA::addPredicate(PTRef pred) {
@@ -820,11 +836,12 @@ bool IC3IA::checkAndRefine(std::size_t & outDepth) {
         if (subst.empty()) { return fla; }
         return TermUtils(logic_).varSubstitute(fla, subst);
     };
+    std::unordered_set<uint32_t> candidateSet;
     auto absorbAtomsFrom = [&](PTRef itp) {
         std::vector<PTRef> atoms;
         collectAtoms(itp, atoms);
         for (PTRef a : atoms) {
-            if (std::find(candidatePredicates.begin(), candidatePredicates.end(), a) == candidatePredicates.end()) {
+            if (candidateSet.insert(a.x).second) {
                 candidatePredicates.push_back(a);
             }
         }

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -387,12 +387,23 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
         if (result.answer == VerificationAnswer::SAFE) {
             PTRef abstractInv = std::get<PTRef>(result.witness);
             PTRef concreteInv = concreteInvariant(abstractInv);
+            if (addInitialReset_) {
+                // Substitute reset → false to eliminate the internal reset variable.
+                // In all reachable states of the original system, reset is always false.
+                TimeMachine tm{logic_};
+                PTRef resetVar = tm.getVarVersionZero("ic3ia_reset", logic_.getSort_bool());
+                TermUtils::substitutions_map subst;
+                subst[resetVar] = logic_.getTerm_false();
+                concreteInv = TermUtils(logic_).varSubstitute(concreteInv, subst);
+            }
             return {VerificationAnswer::SAFE, concreteInv};
         }
 
         if (result.answer == VerificationAnswer::UNSAFE) {
             std::size_t realDepth = 0;
             if (checkAndRefine(realDepth)) {
+                // The reset transformation adds one extra step at the front; subtract it.
+                if (addInitialReset_ && realDepth > 0) { --realDepth; }
                 return {VerificationAnswer::UNSAFE, realDepth};
             }
             if (verbosity_ > 0) {

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 namespace golem {
 
@@ -33,17 +34,13 @@ IC3IA::IC3IA(Logic & logic, Options const & options) : logic_(logic) {
         options.getOrDefault(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "false") == "true";
     addInitialReset_ =
         options.getOrDefault(Options::IC3IA_ADD_INITIAL_RESET, "true") == "true";
+    makeSimpleProperty_ =
+        options.getOrDefault(Options::IC3IA_MAKE_SIMPLE_PROPERTY, "false") == "true";
 }
 
 //=============================================================================
-// IC3 core — reset and main loop
+// IC3 core — main loop
 //=============================================================================
-
-void IC3IA::resetIC3State() {
-    depth_ = 0;
-    clauses_.clear();
-    cexTrace_.clear();
-}
 
 TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
     if (verbosity_ > 0) { std::cout << "[IC3] " << (resuming ? "Resuming" : "Starting") << "\n"; }
@@ -51,10 +48,11 @@ TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
     if (!resuming) {
         // Base check: Init ∧ bad SAT → immediately unsafe.
         {
-            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
-            solver.assertProp(init_);
-            solver.assertProp(bad_);
-            if (solver.check() == SMTSolver::Answer::SAT) {
+            initSolver_->push();
+            initSolver_->assertProp(bad_);
+            auto const res = initSolver_->check();
+            initSolver_->pop();
+            if (res == SMTSolver::Answer::SAT) {
                 if (verbosity_ > 0) { std::cout << "[IC3] Initial states satisfy bad\n"; }
                 return {VerificationAnswer::UNSAFE, 0u};
             }
@@ -67,7 +65,7 @@ TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
         if (verbosity_ > 0) { std::cout << "[IC3] Depth = " << depth_ << "\n"; }
 
         Cube badCube;
-        while (hasBadSuccessor(badCube)) {
+        while (hasBadState(badCube)) {
             if (!blockObligations(Obligation{badCube, depth_, nullptr})) {
                 if (verbosity_ > 0) { std::cout << "[IC3] Counterexample found\n"; }
                 return {VerificationAnswer::UNSAFE, depth_};
@@ -161,10 +159,13 @@ bool IC3IA::initIntersects(Cube const & cube) const {
     return res == SMTSolver::Answer::SAT;
 }
 
-bool IC3IA::hasBadSuccessor(Cube & outCube) const {
+bool IC3IA::hasBadState(Cube & outCube) const {
+    // Disable the trans relation via transAct_ so the query is over a single
+    // current state (label-defs still apply, giving labels their meaning).
     transSolver_->push();
+    transSolver_->assertProp(logic_.mkNot(transAct_));
     transSolver_->assertProp(getF(depth_));
-    transSolver_->assertProp(prime(bad_));
+    transSolver_->assertProp(bad_);
     auto const res = transSolver_->check();
     bool const sat = res == SMTSolver::Answer::SAT;
     if (sat) { outCube = modelToCube(transSolver_->getModel(), stateVars_); }
@@ -175,6 +176,7 @@ bool IC3IA::hasBadSuccessor(Cube & outCube) const {
 bool IC3IA::hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
                                  Cube & outCTI) const {
     transSolver_->push();
+    transSolver_->assertProp(transAct_);
     transSolver_->assertProp(frameFormula);
     transSolver_->assertProp(prime(cubeToFla(cube)));
     auto const res = transSolver_->check();
@@ -334,6 +336,7 @@ bool IC3IA::propagateClauses() {
             if (c.level != i) { continue; }
             PTRef negClausePrimed = prime(logic_.mkNot(c.fla));
             transSolver_->push();
+            transSolver_->assertProp(transAct_);
             transSolver_->assertProp(getF(i));
             transSolver_->assertProp(negClausePrimed);
             auto const res = transSolver_->check();
@@ -370,6 +373,11 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
     concreteStateVars_    = system.getStateVars();
     concreteNextStateVars_= system.getNextStateVars();
 
+    simplePropOrigBad_ = PTRef_Undef;
+    simplePropVar_ = PTRef_Undef;
+    if (makeSimpleProperty_) {
+        applySimpleProperty();
+    }
     if (addInitialReset_) {
         applyInitialReset();
     }
@@ -385,14 +393,10 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
     }
 
     initializeAbstractSystem();
-    resetIC3State();
 
-    static constexpr unsigned maxRefinements = 1000;
-    for (unsigned iter = 0; iter < maxRefinements; ++iter) {
+    for (unsigned iter = 0; ; ++iter) {
         // Resume after the first iteration: keep frames, depth, and learned
-        // clauses across CEGAR refinements. Soundness comes from the paper's
-        // Lemma 1, so previously inductive clauses remain
-        // inductive in the strengthened abstract system.
+        // clauses across CEGAR refinements. 
         auto result = runIC3(/*resuming=*/iter > 0);
 
         if (result.answer == VerificationAnswer::SAFE) {
@@ -405,6 +409,11 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
                 PTRef resetVar = tm.getVarVersionZero("ic3ia_reset", logic_.getSort_bool());
                 TermUtils::substitutions_map subst;
                 subst[resetVar] = logic_.getTerm_false();
+                concreteInv = TermUtils(logic_).varSubstitute(concreteInv, subst);
+            }
+            if (makeSimpleProperty_ && simplePropVar_ != PTRef_Undef) {
+                TermUtils::substitutions_map subst;
+                subst[simplePropVar_] = simplePropOrigBad_;
                 concreteInv = TermUtils(logic_).varSubstitute(concreteInv, subst);
             }
             return {VerificationAnswer::SAFE, concreteInv};
@@ -429,8 +438,6 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
 
         return result;
     }
-
-    return {VerificationAnswer::UNKNOWN, 0u};
 }
 
 //=============================================================================
@@ -472,19 +479,16 @@ PTRef IC3IA::shiftFormulaThroughTime(PTRef fla, int steps) const {
 void IC3IA::collectAtoms(PTRef fla, std::vector<PTRef> & atoms) const {
     if (logic_.isTrue(fla) || logic_.isFalse(fla)) { return; }
 
-    Pterm const & t = logic_.getPterm(fla);
+    if (logic_.isAtom(fla)) {
+        if (std::find(atoms.begin(), atoms.end(), fla) == atoms.end()) {
+            atoms.push_back(fla);
+        }
+        return;
+    }
 
-    if (logic_.isAnd(fla) || logic_.isOr(fla)) {
-        for (int i = 0; i < t.size(); ++i) { collectAtoms(t[i], atoms); }
-        return;
-    }
-    if (logic_.isNot(fla)) {
-        collectAtoms(t[0], atoms);
-        return;
-    }
-    if (std::find(atoms.begin(), atoms.end(), fla) == atoms.end()) {
-        atoms.push_back(fla);
-    }
+    // Boolean connective: descend into all children.
+    Pterm const & t = logic_.getPterm(fla);
+    for (int i = 0; i < t.size(); ++i) { collectAtoms(t[i], atoms); }
 }
 
 std::vector<PTRef> IC3IA::minimizeRefinementPredicateSet(std::vector<PTRef> candidates,
@@ -575,6 +579,34 @@ bool IC3IA::addPredicate(PTRef pred) {
     return true;
 }
 
+void IC3IA::applySimpleProperty() {
+    // Skip if bad is already a single Boolean state var.
+    if (logic_.isVar(concreteBad_) && logic_.hasSortBool(concreteBad_)) {
+        return;
+    }
+    TimeMachine tm{logic_};
+    PTRef p     = tm.getVarVersionZero("ic3ia_simpleprop", logic_.getSort_bool());
+    PTRef pNext = tm.sendVarThroughTime(p, 1);
+
+    PTRef oldInit  = concreteInit_;
+    PTRef oldTrans = concreteTrans_;
+    PTRef oldBad   = concreteBad_;
+    PTRef badNext  = atTime(oldBad, 1);
+
+    concreteInit_  = logic_.mkAnd(oldInit, logic_.mkEq(p, oldBad));
+    concreteTrans_ = logic_.mkAnd({oldTrans, logic_.mkEq(p, oldBad), logic_.mkEq(pNext, badNext)});
+    concreteBad_   = p;
+    concreteStateVars_.push_back(p);
+    concreteNextStateVars_.push_back(pNext);
+
+    simplePropOrigBad_ = oldBad;
+    simplePropVar_     = p;
+
+    if (verbosity_ > 0) {
+        std::cout << "[IC3IA] Replaced property with single state var\n";
+    }
+}
+
 void IC3IA::applyInitialReset() {
     TimeMachine tm{logic_};
     PTRef reset = tm.getVarVersionZero("ic3ia_reset", logic_.getSort_bool());
@@ -653,7 +685,8 @@ void IC3IA::initializeAbstractSystem() {
     initSolver_  = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::NONE);
     transSolver_ = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
     initSolver_->assertProp(concreteInit_);
-    transSolver_->assertProp(concreteTrans_);
+    transAct_ = logic_.mkBoolVar(".ic3ia_trans_act");
+    transSolver_->assertProp(logic_.mkOr(logic_.mkNot(transAct_), concreteTrans_));
 
     extendAbstractSystem();
 }
@@ -671,8 +704,8 @@ void IC3IA::extendAbstractSystem() {
     PTRef newLabelDefs =
         newLabelDefParts.size() == 1 ? newLabelDefParts[0] : logic_.mkAnd(newLabelDefParts);
 
-    init_ = logic_.mkAnd(init_, newLabelDefs);
-    bad_  = logic_.mkAnd(bad_,  newLabelDefs);
+    init_ = abstractFormula(concreteInit_);
+    bad_  = abstractFormula(concreteBad_);
 
     vec<PTRef> transParts;
     transParts.push(trans_);
@@ -711,7 +744,11 @@ PTRef IC3IA::atTime(PTRef fla, unsigned steps) const {
 }
 
 bool IC3IA::checkAndRefine(std::size_t & outDepth) {
-    std::size_t const k = cexTrace_.empty() ? depth_ : cexTrace_.size();
+    // cexTrace_ contains depth_+1 cubes: cexTrace_[i] is a guide for time i,
+    // and cexTrace_.back() is the original bad-state cube (top of the
+    // obligation chain). Number of transitions is one less than the number of
+    // time points.
+    std::size_t const k = cexTrace_.empty() ? depth_ : cexTrace_.size() - 1;
     auto const refineStart = std::chrono::steady_clock::now();
 
     if (verbosity_ > 1) {
@@ -719,28 +756,31 @@ bool IC3IA::checkAndRefine(std::size_t & outDepth) {
     }
 
     SMTSolver solver(logic_, SMTSolver::WitnessProduction::MODEL_AND_INTERPOLANTS);
+
     solver.getConfig().setSimplifyInterpolant(4);
 
-    auto guidedStateFormulaAt = [&](std::size_t index) {
+    auto guideAt = [&](std::size_t index) -> PTRef {
         if (cexTrace_.empty() || index >= cexTrace_.size()) { return logic_.getTerm_true(); }
         return atTime(concreteInvariant(cubeToFla(cexTrace_[index])), static_cast<unsigned>(index));
     };
 
-    vec<PTRef> initParts;
-    initParts.push(concreteInit_);
-    PTRef guideAtZero = guidedStateFormulaAt(0);
-    if (guideAtZero != logic_.getTerm_true()) { initParts.push(guideAtZero); }
-    solver.assertProp(initParts.size() == 1 ? initParts[0] : logic_.mkAnd(initParts));
-
     for (std::size_t i = 0; i < k; ++i) {
-        vec<PTRef> transParts;
-        transParts.push(atTime(concreteTrans_, static_cast<unsigned>(i)));
-        PTRef guidedState = guidedStateFormulaAt(i + 1);
-        if (guidedState != logic_.getTerm_true()) { transParts.push(guidedState); }
-        solver.assertProp(transParts.size() == 1 ? transParts[0] : logic_.mkAnd(transParts));
+        vec<PTRef> parts;
+        if (i == 0) { parts.push(concreteInit_); }
+        PTRef g = guideAt(i);
+        if (g != logic_.getTerm_true()) { parts.push(g); }
+        parts.push(atTime(concreteTrans_, static_cast<unsigned>(i)));
+        solver.assertProp(parts.size() == 1 ? parts[0] : logic_.mkAnd(parts));
     }
 
-    solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(k)));
+    {
+        PTRef bg = guideAt(k);
+        if (bg == logic_.getTerm_true()) {
+            solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(k)));
+        } else {
+            solver.assertProp(bg);
+        }
+    }
 
     auto const solveStart = std::chrono::steady_clock::now();
     auto res = solver.check();
@@ -763,48 +803,48 @@ bool IC3IA::checkAndRefine(std::size_t & outDepth) {
     }
 
     auto itpCtx = solver.getInterpolationContext();
-    vec<PTRef> interpolantsVec;
-    std::vector<ipartitions_t> pathMasks;
-    pathMasks.reserve(k);
-    for (std::size_t i = 0; i < k; ++i) {
-        ipartitions_t mask = 0;
-        for (std::size_t j = 0; j <= i + 1; ++j) {
-            opensmt::setbit(mask, static_cast<unsigned>(j));
-        }
-        pathMasks.push_back(mask);
-    }
     auto const interpolationStart = std::chrono::steady_clock::now();
-    if (not pathMasks.empty()) {
-        if (useBinaryRefinementInterpolants_) {
-            for (ipartitions_t mask : pathMasks) {
-                std::vector<PTRef> single;
-                itpCtx->getSingleInterpolant(single, mask);
-                if (!single.empty()) { interpolantsVec.push(single.front()); }
-            }
-        } else {
-            itpCtx->getPathInterpolants(interpolantsVec, pathMasks);
-        }
-    }
-    auto const interpolationEnd = std::chrono::steady_clock::now();
-
-    std::vector<PTRef> interpolants;
-    interpolants.reserve(interpolantsVec.size());
-    for (PTRef itp : interpolantsVec) { interpolants.push_back(itp); }
 
     std::vector<PTRef> unshiftedInterpolants;
-    unshiftedInterpolants.reserve(interpolants.size());
+    unshiftedInterpolants.reserve(k);
     std::vector<PTRef> candidatePredicates;
-    for (std::size_t i = 0; i < interpolants.size(); ++i) {
-        PTRef unshifted = shiftFormulaThroughTime(interpolants[i], -static_cast<int>(i + 1));
-        unshiftedInterpolants.push_back(unshifted);
+
+    auto untimeToZero = [&](PTRef fla) -> PTRef {
+        TimeMachine tm{logic_};
+        std::vector<PTRef> vars;
+        collectVars(fla, vars);
+        TermUtils::substitutions_map subst;
+        for (PTRef v : vars) {
+            if (!tm.isVersioned(v)) { continue; }
+            int ver = tm.getVersionNumber(v);
+            if (ver == 0) { continue; }
+            subst[v] = tm.sendVarThroughTime(v, -ver);
+        }
+        if (subst.empty()) { return fla; }
+        return TermUtils(logic_).varSubstitute(fla, subst);
+    };
+    auto absorbAtomsFrom = [&](PTRef itp) {
         std::vector<PTRef> atoms;
-        collectAtoms(unshifted, atoms);
+        collectAtoms(itp, atoms);
         for (PTRef a : atoms) {
             if (std::find(candidatePredicates.begin(), candidatePredicates.end(), a) == candidatePredicates.end()) {
                 candidatePredicates.push_back(a);
             }
         }
+    };
+    for (std::size_t i = 0; i < k; ++i) {
+        ipartitions_t mask = 0;
+        for (std::size_t j = 0; j <= i; ++j) {
+            opensmt::setbit(mask, static_cast<unsigned>(j));
+        }
+        std::vector<PTRef> single;
+        itpCtx->getSingleInterpolant(single, mask);
+        if (single.empty()) { continue; }
+        PTRef untimed = untimeToZero(single.front());
+        unshiftedInterpolants.push_back(untimed);
+        absorbAtomsFrom(untimed);
     }
+    auto const interpolationEnd = std::chrono::steady_clock::now();
 
     if (minimizeRefinementPredicates_) {
         auto minimized = minimizeRefinementPredicateSet(candidatePredicates, unshiftedInterpolants, k);
@@ -825,7 +865,11 @@ bool IC3IA::checkAndRefine(std::size_t & outDepth) {
     }
 
     if (newPreds == 0) {
-        for (PTRef itp : unshiftedInterpolants) { addPredicate(itp); }
+        std::cerr << "[IC3IA] refinement extracted 0 new predicates. k=" << k
+                  << ", existing predicates=" << predicates_.size() << "\n";
+        throw std::runtime_error(
+            "IC3IA refinement failure: no new predicates extracted from "
+            "interpolants of a spurious counterexample");
     }
 
     if (verbosity_ > 1) {

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -45,21 +45,23 @@ void IC3IA::resetIC3State() {
     cexTrace_.clear();
 }
 
-TransitionSystemVerificationResult IC3IA::runIC3() {
-    if (verbosity_ > 0) { std::cout << "[IC3] Starting\n"; }
+TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
+    if (verbosity_ > 0) { std::cout << "[IC3] " << (resuming ? "Resuming" : "Starting") << "\n"; }
 
-    // Base check: Init ∧ bad SAT → immediately unsafe.
-    {
-        SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
-        solver.assertProp(init_);
-        solver.assertProp(bad_);
-        if (solver.check() == SMTSolver::Answer::SAT) {
-            if (verbosity_ > 0) { std::cout << "[IC3] Initial states satisfy bad\n"; }
-            return {VerificationAnswer::UNSAFE, 0u};
+    if (!resuming) {
+        // Base check: Init ∧ bad SAT → immediately unsafe.
+        {
+            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
+            solver.assertProp(init_);
+            solver.assertProp(bad_);
+            if (solver.check() == SMTSolver::Answer::SAT) {
+                if (verbosity_ > 0) { std::cout << "[IC3] Initial states satisfy bad\n"; }
+                return {VerificationAnswer::UNSAFE, 0u};
+            }
         }
-    }
 
-    pushFrame(); // depth_ = 1
+        pushFrame(); // depth_ = 1
+    }
 
     while (true) {
         if (verbosity_ > 0) { std::cout << "[IC3] Depth = " << depth_ << "\n"; }
@@ -152,31 +154,34 @@ IC3IA::Cube IC3IA::modelToCube(std::shared_ptr<Model> const & model,
 //=============================================================================
 
 bool IC3IA::initIntersects(Cube const & cube) const {
-    SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
-    solver.assertProp(init_);
-    solver.assertProp(cubeToFla(cube));
-    return solver.check() == SMTSolver::Answer::SAT;
+    initSolver_->push();
+    initSolver_->assertProp(cubeToFla(cube));
+    auto const res = initSolver_->check();
+    initSolver_->pop();
+    return res == SMTSolver::Answer::SAT;
 }
 
 bool IC3IA::hasBadSuccessor(Cube & outCube) const {
-    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
-    solver.assertProp(getF(depth_));
-    solver.assertProp(trans_);
-    solver.assertProp(prime(bad_));
-    if (solver.check() != SMTSolver::Answer::SAT) { return false; }
-    outCube = modelToCube(solver.getModel(), stateVars_);
-    return true;
+    transSolver_->push();
+    transSolver_->assertProp(getF(depth_));
+    transSolver_->assertProp(prime(bad_));
+    auto const res = transSolver_->check();
+    bool const sat = res == SMTSolver::Answer::SAT;
+    if (sat) { outCube = modelToCube(transSolver_->getModel(), stateVars_); }
+    transSolver_->pop();
+    return sat;
 }
 
 bool IC3IA::hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
                                  Cube & outCTI) const {
-    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
-    solver.assertProp(frameFormula);
-    solver.assertProp(trans_);
-    solver.assertProp(prime(cubeToFla(cube)));
-    if (solver.check() != SMTSolver::Answer::SAT) { return false; }
-    outCTI = modelToCube(solver.getModel(), stateVars_);
-    return true;
+    transSolver_->push();
+    transSolver_->assertProp(frameFormula);
+    transSolver_->assertProp(prime(cubeToFla(cube)));
+    auto const res = transSolver_->check();
+    bool const sat = res == SMTSolver::Answer::SAT;
+    if (sat) { outCTI = modelToCube(transSolver_->getModel(), stateVars_); }
+    transSolver_->pop();
+    return sat;
 }
 
 bool IC3IA::hasPredecessor(Cube const & cube, unsigned level, Cube & outCTI) const {
@@ -328,11 +333,12 @@ bool IC3IA::propagateClauses() {
         for (auto & c : clauses_) {
             if (c.level != i) { continue; }
             PTRef negClausePrimed = prime(logic_.mkNot(c.fla));
-            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
-            solver.assertProp(getF(i));
-            solver.assertProp(trans_);
-            solver.assertProp(negClausePrimed);
-            if (solver.check() == SMTSolver::Answer::UNSAT) {
+            transSolver_->push();
+            transSolver_->assertProp(getF(i));
+            transSolver_->assertProp(negClausePrimed);
+            auto const res = transSolver_->check();
+            transSolver_->pop();
+            if (res == SMTSolver::Answer::UNSAT) {
                 c.level = i + 1;
             }
         }
@@ -378,11 +384,16 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
         std::cout << "[IC3IA] Initial predicates: " << predicates_.size() << "\n";
     }
 
+    initializeAbstractSystem();
+    resetIC3State();
+
     static constexpr unsigned maxRefinements = 1000;
     for (unsigned iter = 0; iter < maxRefinements; ++iter) {
-        setupAbstractSystem();
-
-        auto result = runIC3();
+        // Resume after the first iteration: keep frames, depth, and learned
+        // clauses across CEGAR refinements. Soundness comes from the paper's
+        // Lemma 1, so previously inductive clauses remain
+        // inductive in the strengthened abstract system.
+        auto result = runIC3(/*resuming=*/iter > 0);
 
         if (result.answer == VerificationAnswer::SAFE) {
             PTRef abstractInv = std::get<PTRef>(result.witness);
@@ -411,6 +422,8 @@ TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system)
                           << std::get<std::size_t>(result.witness)
                           << "; predicates now: " << predicates_.size() << "\n";
             }
+            extendAbstractSystem();
+            cexTrace_.clear();
             continue;
         }
 
@@ -627,31 +640,57 @@ PTRef IC3IA::abstractFormula(PTRef fla) const {
     return fla;
 }
 
-void IC3IA::setupAbstractSystem() {
+void IC3IA::initializeAbstractSystem() {
     assert(!predicates_.empty());
 
-    vec<PTRef> labelDefParts;
-    for (std::size_t i = 0; i < predicates_.size(); ++i) {
-        labelDefParts.push(logic_.mkEq(predLabels_[i], predicates_[i]));
-    }
-    PTRef labelDefs = logic_.mkAnd(labelDefParts);
+    init_  = concreteInit_;
+    bad_   = concreteBad_;
+    trans_ = concreteTrans_;
+    stateVars_.clear();
+    nextStateVars_.clear();
+    numAssertedPreds_ = 0;
 
-    init_ = logic_.mkAnd(concreteInit_, labelDefs);
-    bad_  = logic_.mkAnd(concreteBad_,  labelDefs);
+    initSolver_  = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::NONE);
+    transSolver_ = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
+    initSolver_->assertProp(concreteInit_);
+    transSolver_->assertProp(concreteTrans_);
+
+    extendAbstractSystem();
+}
+
+void IC3IA::extendAbstractSystem() {
+    if (numAssertedPreds_ == predicates_.size()) { return; }
+
+    vec<PTRef> newLabelDefParts;
+    vec<PTRef> newNextDefParts;
+    for (std::size_t i = numAssertedPreds_; i < predicates_.size(); ++i) {
+        newLabelDefParts.push(logic_.mkEq(predLabels_[i], predicates_[i]));
+        PTRef pNext = shiftFormulaThroughTime(predicates_[i], 1);
+        newNextDefParts.push(logic_.mkEq(predLabelsNext_[i], pNext));
+    }
+    PTRef newLabelDefs =
+        newLabelDefParts.size() == 1 ? newLabelDefParts[0] : logic_.mkAnd(newLabelDefParts);
+
+    init_ = logic_.mkAnd(init_, newLabelDefs);
+    bad_  = logic_.mkAnd(bad_,  newLabelDefs);
 
     vec<PTRef> transParts;
-    transParts.push(concreteTrans_);
-    transParts.push(labelDefs);
-    for (std::size_t i = 0; i < predicates_.size(); ++i) {
-        PTRef pNext = shiftFormulaThroughTime(predicates_[i], 1);
-        transParts.push(logic_.mkEq(predLabelsNext_[i], pNext));
-    }
+    transParts.push(trans_);
+    transParts.push(newLabelDefs);
+    for (int i = 0; i < newNextDefParts.size(); ++i) { transParts.push(newNextDefParts[i]); }
     trans_ = logic_.mkAnd(transParts);
+
+    // Mirror the new conjuncts into the persistent query solvers.
+    initSolver_->assertProp(newLabelDefs);
+    transSolver_->assertProp(newLabelDefs);
+    for (int i = 0; i < newNextDefParts.size(); ++i) {
+        transSolver_->assertProp(newNextDefParts[i]);
+    }
 
     stateVars_     = predLabels_;
     nextStateVars_ = predLabelsNext_;
 
-    resetIC3State();
+    numAssertedPreds_ = predicates_.size();
 }
 
 PTRef IC3IA::concreteInvariant(PTRef abstractInv) const {

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -28,10 +28,6 @@ IC3IA::IC3IA(Logic & logic, Options const & options) : logic_(logic) {
     computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
     useUnsatCoreGeneralization_ =
     options.getOrDefault(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true") == "true";
-    minimizeRefinementPredicates_ =
-        options.getOrDefault(Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES, "true") == "true";
-    useBinaryRefinementInterpolants_ =
-        options.getOrDefault(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "false") == "true";
     addInitialReset_ =
         options.getOrDefault(Options::IC3IA_ADD_INITIAL_RESET, "true") == "true";
     makeSimpleProperty_ =
@@ -90,7 +86,7 @@ TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
                     return {VerificationAnswer::SAFE, buildInvariant(i)};
                 }
             }
-            return {VerificationAnswer::SAFE, logic_.getTerm_true()};
+            throw std::logic_error("IC3IA: propagateClauses reported fixpoint but no empty level was found");
         }
     }
 }
@@ -300,8 +296,7 @@ bool IC3IA::blockObligations(Obligation seed) {
         }
 
         if (obl.level == 0) {
-            // Vacuity check above already proved init ∧ cube SAT,
-            // so reaching level 0 means we have a real counterexample.
+            // reaching level 0 means we have a counterexample.
             cexTrace_.clear();
             Obligation const * cur = &obl;
             while (cur) {
@@ -316,10 +311,6 @@ bool IC3IA::blockObligations(Obligation seed) {
             auto oblPtr = std::make_shared<Obligation>(obl);
             pq.push(Obligation{std::move(cti), obl.level - 1, std::move(oblPtr)});
             pq.push(std::move(obl));
-        } else if (initIntersects(obl.cube)) {
-            // No predecessor, but the cube is in init — push to level 0
-            // so the level-0 handler recognizes it as a real counterexample.
-            pq.push(Obligation{obl.cube, 0, obl.successor});
         } else {
             Cube gen = generalize(obl.cube, obl.level);
             PTRef clause = logic_.mkNot(cubeToFla(gen));
@@ -838,21 +829,25 @@ bool IC3IA::checkAndRefine(std::size_t & outDepth) {
             }
         }
     };
-    for (std::size_t i = 0; i < k; ++i) {
+    {
+        std::vector<ipartitions_t> masks;
+        masks.reserve(k);
         ipartitions_t mask = 0;
-        for (std::size_t j = 0; j <= i; ++j) {
-            opensmt::setbit(mask, static_cast<unsigned>(j));
+        for (std::size_t i = 0; i < k; ++i) {
+            opensmt::setbit(mask, static_cast<unsigned>(i));
+            masks.push_back(mask);
         }
-        std::vector<PTRef> single;
-        itpCtx->getSingleInterpolant(single, mask);
-        if (single.empty()) { continue; }
-        PTRef untimed = untimeToZero(single.front());
-        unshiftedInterpolants.push_back(untimed);
-        absorbAtomsFrom(untimed);
+        vec<PTRef> itps;
+        itpCtx->getPathInterpolants(itps, masks);
+        for (int i = 0; i < itps.size(); ++i) {
+            PTRef untimed = untimeToZero(itps[i]);
+            unshiftedInterpolants.push_back(untimed);
+            absorbAtomsFrom(untimed);
+        }
     }
     auto const interpolationEnd = std::chrono::steady_clock::now();
 
-    if (minimizeRefinementPredicates_) {
+    {
         auto minimized = minimizeRefinementPredicateSet(candidatePredicates, unshiftedInterpolants, k);
         if (verbosity_ > 0 && minimized.size() < candidatePredicates.size()) {
             std::cout << "[IC3IA] Minimized refinement predicates from "

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -48,10 +48,12 @@ TransitionSystemVerificationResult IC3IA::runIC3(bool resuming) {
     if (!resuming) {
         // Base check: Init ∧ bad SAT → immediately unsafe.
         {
-            initSolver_->push();
-            initSolver_->assertProp(bad_);
-            auto const res = initSolver_->check();
-            initSolver_->pop();
+            solver_->push();
+            solver_->assertProp(initAct_);
+            solver_->assertProp(logic_.mkNot(transAct_));
+            solver_->assertProp(bad_);
+            auto const res = solver_->check();
+            solver_->pop();
             if (res == SMTSolver::Answer::SAT) {
                 if (verbosity_ > 0) { std::cout << "[IC3] Initial states satisfy bad\n"; }
                 return {VerificationAnswer::UNSAFE, 0u};
@@ -152,37 +154,39 @@ IC3IA::Cube IC3IA::modelToCube(std::shared_ptr<Model> const & model,
 //=============================================================================
 
 bool IC3IA::initIntersects(Cube const & cube) const {
-    initSolver_->push();
-    initSolver_->assertProp(cubeToFla(cube));
-    auto const res = initSolver_->check();
-    initSolver_->pop();
+    solver_->push();
+    solver_->assertProp(initAct_);
+    solver_->assertProp(logic_.mkNot(transAct_));
+    solver_->assertProp(cubeToFla(cube));
+    auto const res = solver_->check();
+    solver_->pop();
     return res == SMTSolver::Answer::SAT;
 }
 
 bool IC3IA::hasBadState(Cube & outCube) const {
     // Disable the trans relation via transAct_ so the query is over a single
     // current state (label-defs still apply, giving labels their meaning).
-    transSolver_->push();
-    transSolver_->assertProp(logic_.mkNot(transAct_));
-    transSolver_->assertProp(getF(depth_));
-    transSolver_->assertProp(bad_);
-    auto const res = transSolver_->check();
+    solver_->push();
+    solver_->assertProp(logic_.mkNot(transAct_));
+    solver_->assertProp(getF(depth_));
+    solver_->assertProp(bad_);
+    auto const res = solver_->check();
     bool const sat = res == SMTSolver::Answer::SAT;
-    if (sat) { outCube = modelToCube(transSolver_->getModel(), stateVars_); }
-    transSolver_->pop();
+    if (sat) { outCube = modelToCube(solver_->getModel(), stateVars_); }
+    solver_->pop();
     return sat;
 }
 
 bool IC3IA::hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
                                  Cube & outCTI) const {
-    transSolver_->push();
-    transSolver_->assertProp(transAct_);
-    transSolver_->assertProp(frameFormula);
-    transSolver_->assertProp(prime(cubeToFla(cube)));
-    auto const res = transSolver_->check();
+    solver_->push();
+    solver_->assertProp(transAct_);
+    solver_->assertProp(frameFormula);
+    solver_->assertProp(prime(cubeToFla(cube)));
+    auto const res = solver_->check();
     bool const sat = res == SMTSolver::Answer::SAT;
-    if (sat) { outCTI = modelToCube(transSolver_->getModel(), stateVars_); }
-    transSolver_->pop();
+    if (sat) { outCTI = modelToCube(solver_->getModel(), stateVars_); }
+    solver_->pop();
     return sat;
 }
 
@@ -283,25 +287,28 @@ bool IC3IA::blockObligations(Obligation seed) {
         Obligation obl = pq.top();
         pq.pop();
 
+        // Sanity check: skip obligations whose cube is no longer reachable
+        // in F[level] (e.g., already blocked by a pushed clause).
         {
-            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
-            solver.assertProp(getF(obl.level));
-            solver.assertProp(cubeToFla(obl.cube));
-            if (solver.check() == SMTSolver::Answer::UNSAT) { continue; }
+            solver_->push();
+            solver_->assertProp(logic_.mkNot(transAct_));
+            solver_->assertProp(getF(obl.level));
+            solver_->assertProp(cubeToFla(obl.cube));
+            auto const res = solver_->check();
+            solver_->pop();
+            if (res == SMTSolver::Answer::UNSAT) { continue; }
         }
 
         if (obl.level == 0) {
-            if (initIntersects(obl.cube)) {
-                cexTrace_.clear();
-                Obligation const * cur = &obl;
-                while (cur) {
-                    cexTrace_.push_back(cur->cube);
-                    cur = cur->successor.get();
-                }
-                return false;
+            // Vacuity check above already proved init ∧ cube SAT,
+            // so reaching level 0 means we have a real counterexample.
+            cexTrace_.clear();
+            Obligation const * cur = &obl;
+            while (cur) {
+                cexTrace_.push_back(cur->cube);
+                cur = cur->successor.get();
             }
-            addClause(logic_.mkNot(cubeToFla(obl.cube)), 1u);
-            continue;
+            return false;
         }
 
         Cube cti;
@@ -335,12 +342,12 @@ bool IC3IA::propagateClauses() {
         for (auto & c : clauses_) {
             if (c.level != i) { continue; }
             PTRef negClausePrimed = prime(logic_.mkNot(c.fla));
-            transSolver_->push();
-            transSolver_->assertProp(transAct_);
-            transSolver_->assertProp(getF(i));
-            transSolver_->assertProp(negClausePrimed);
-            auto const res = transSolver_->check();
-            transSolver_->pop();
+            solver_->push();
+            solver_->assertProp(transAct_);
+            solver_->assertProp(getF(i));
+            solver_->assertProp(negClausePrimed);
+            auto const res = solver_->check();
+            solver_->pop();
             if (res == SMTSolver::Answer::UNSAT) {
                 c.level = i + 1;
             }
@@ -682,11 +689,11 @@ void IC3IA::initializeAbstractSystem() {
     nextStateVars_.clear();
     numAssertedPreds_ = 0;
 
-    initSolver_  = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::NONE);
-    transSolver_ = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
-    initSolver_->assertProp(concreteInit_);
+    solver_ = std::make_unique<SMTSolver>(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
+    initAct_  = logic_.mkBoolVar(".ic3ia_init_act");
     transAct_ = logic_.mkBoolVar(".ic3ia_trans_act");
-    transSolver_->assertProp(logic_.mkOr(logic_.mkNot(transAct_), concreteTrans_));
+    solver_->assertProp(logic_.mkOr(logic_.mkNot(initAct_),  concreteInit_));
+    solver_->assertProp(logic_.mkOr(logic_.mkNot(transAct_), concreteTrans_));
 
     extendAbstractSystem();
 }
@@ -713,11 +720,10 @@ void IC3IA::extendAbstractSystem() {
     for (int i = 0; i < newNextDefParts.size(); ++i) { transParts.push(newNextDefParts[i]); }
     trans_ = logic_.mkAnd(transParts);
 
-    // Mirror the new conjuncts into the persistent query solvers.
-    initSolver_->assertProp(newLabelDefs);
-    transSolver_->assertProp(newLabelDefs);
+    // Mirror the new conjuncts into the persistent query solver.
+    solver_->assertProp(newLabelDefs);
     for (int i = 0; i < newNextDefParts.size(); ++i) {
-        transSolver_->assertProp(newNextDefParts[i]);
+        solver_->assertProp(newNextDefParts[i]);
     }
 
     stateVars_     = predLabels_;

--- a/src/engine/IC3IA.cc
+++ b/src/engine/IC3IA.cc
@@ -1,0 +1,795 @@
+/*
+ * Copyright (c) 2025
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "IC3IA.h"
+
+#include "Common.h"
+#include "TermUtils.h"
+#include "TransformationUtils.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <sstream>
+
+namespace golem {
+
+//=============================================================================
+// Constructor
+//=============================================================================
+
+IC3IA::IC3IA(Logic & logic, Options const & options) : logic_(logic) {
+    verbosity_ = std::stoi(options.getOrDefault(Options::VERBOSE, "0"));
+    computeWitness = options.getOrDefault(Options::COMPUTE_WITNESS, "") == "true";
+    useUnsatCoreGeneralization_ =
+    options.getOrDefault(Options::IC3IA_USE_UNSAT_CORE_GENERALIZATION, "true") == "true";
+    minimizeRefinementPredicates_ =
+        options.getOrDefault(Options::IC3IA_MINIMIZE_REFINEMENT_PREDICATES, "true") == "true";
+    useBinaryRefinementInterpolants_ =
+        options.getOrDefault(Options::IC3IA_USE_BINARY_REFINEMENT_INTERPOLANTS, "false") == "true";
+    addInitialReset_ =
+        options.getOrDefault(Options::IC3IA_ADD_INITIAL_RESET, "true") == "true";
+}
+
+//=============================================================================
+// IC3 core — reset and main loop
+//=============================================================================
+
+void IC3IA::resetIC3State() {
+    depth_ = 0;
+    clauses_.clear();
+    cexTrace_.clear();
+}
+
+TransitionSystemVerificationResult IC3IA::runIC3() {
+    if (verbosity_ > 0) { std::cout << "[IC3] Starting\n"; }
+
+    // Base check: Init ∧ bad SAT → immediately unsafe.
+    {
+        SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
+        solver.assertProp(init_);
+        solver.assertProp(bad_);
+        if (solver.check() == SMTSolver::Answer::SAT) {
+            if (verbosity_ > 0) { std::cout << "[IC3] Initial states satisfy bad\n"; }
+            return {VerificationAnswer::UNSAFE, 0u};
+        }
+    }
+
+    pushFrame(); // depth_ = 1
+
+    while (true) {
+        if (verbosity_ > 0) { std::cout << "[IC3] Depth = " << depth_ << "\n"; }
+
+        Cube badCube;
+        while (hasBadSuccessor(badCube)) {
+            if (!blockObligations(Obligation{badCube, depth_, nullptr})) {
+                if (verbosity_ > 0) { std::cout << "[IC3] Counterexample found\n"; }
+                return {VerificationAnswer::UNSAFE, depth_};
+            }
+            badCube.clear();
+        }
+
+        pushFrame();
+
+        if (propagateClauses()) {
+            for (unsigned i = 1; i < depth_; ++i) {
+                bool hasAtI = false;
+                for (auto const & c : clauses_) {
+                    if (c.level == i) { hasAtI = true; break; }
+                }
+                if (!hasAtI) {
+                    if (verbosity_ > 0) {
+                        std::cout << "[IC3] Fixpoint at level " << i << "\n";
+                    }
+                    return {VerificationAnswer::SAFE, buildInvariant(i)};
+                }
+            }
+            return {VerificationAnswer::SAFE, logic_.getTerm_true()};
+        }
+    }
+}
+
+//=============================================================================
+// IC3 core — frame management
+//=============================================================================
+
+PTRef IC3IA::getF(unsigned k) const {
+    if (k == 0) { return init_; }
+    vec<PTRef> parts;
+    for (auto const & c : clauses_) {
+        if (c.level >= k) { parts.push(c.fla); }
+    }
+    if (parts.size() == 0) { return logic_.getTerm_true(); }
+    return logic_.mkAnd(parts);
+}
+
+void IC3IA::addClause(PTRef clauseFla, unsigned level) {
+    for (auto & c : clauses_) {
+        if (c.fla == clauseFla) {
+            if (c.level < level) { c.level = level; }
+            return;
+        }
+    }
+    clauses_.push_back({clauseFla, level});
+}
+
+//=============================================================================
+// IC3 core — formula helpers
+//=============================================================================
+
+PTRef IC3IA::cubeToFla(Cube const & cube) const {
+    if (cube.empty()) { return logic_.getTerm_true(); }
+    vec<PTRef> lits;
+    for (PTRef lit : cube) { lits.push(lit); }
+    return logic_.mkAnd(lits);
+}
+
+PTRef IC3IA::prime(PTRef fla) const {
+    return shiftFormulaThroughTime(fla, 1);
+}
+
+//=============================================================================
+// IC3 core — model extraction
+//=============================================================================
+
+IC3IA::Cube IC3IA::modelToCube(std::shared_ptr<Model> const & model,
+                                std::vector<PTRef> const & vars) const {
+    Cube cube;
+    cube.reserve(vars.size());
+    for (PTRef var : vars) {
+        PTRef val = model->evaluate(var);
+        cube.push_back(val == logic_.getTerm_true() ? var : logic_.mkNot(var));
+    }
+    return cube;
+}
+
+//=============================================================================
+// IC3 core — queries
+//=============================================================================
+
+bool IC3IA::initIntersects(Cube const & cube) const {
+    SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
+    solver.assertProp(init_);
+    solver.assertProp(cubeToFla(cube));
+    return solver.check() == SMTSolver::Answer::SAT;
+}
+
+bool IC3IA::hasBadSuccessor(Cube & outCube) const {
+    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
+    solver.assertProp(getF(depth_));
+    solver.assertProp(trans_);
+    solver.assertProp(prime(bad_));
+    if (solver.check() != SMTSolver::Answer::SAT) { return false; }
+    outCube = modelToCube(solver.getModel(), stateVars_);
+    return true;
+}
+
+bool IC3IA::hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
+                                 Cube & outCTI) const {
+    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_MODEL);
+    solver.assertProp(frameFormula);
+    solver.assertProp(trans_);
+    solver.assertProp(prime(cubeToFla(cube)));
+    if (solver.check() != SMTSolver::Answer::SAT) { return false; }
+    outCTI = modelToCube(solver.getModel(), stateVars_);
+    return true;
+}
+
+bool IC3IA::hasPredecessor(Cube const & cube, unsigned level, Cube & outCTI) const {
+    assert(level > 0);
+    return hasPredecessorUnder(getF(level - 1), cube, outCTI);
+}
+
+//=============================================================================
+// IC3 core — generalization
+//=============================================================================
+
+IC3IA::Cube IC3IA::generalize(Cube cube, unsigned level) const {
+    if (useUnsatCoreGeneralization_) { return generalizeWithUnsatCore(std::move(cube), level); }
+
+    assert(level > 0);
+    PTRef frameFormula = getF(level - 1);
+    Cube dummy;
+    for (std::size_t i = 0; i < cube.size(); ) {
+        if (cube.size() == 1) { break; }
+        Cube attempt;
+        attempt.reserve(cube.size() - 1);
+        for (std::size_t j = 0; j < cube.size(); ++j) {
+            if (j != i) { attempt.push_back(cube[j]); }
+        }
+        if (!initIntersects(attempt) &&
+            !hasPredecessorUnder(frameFormula, attempt, dummy)) {
+            cube = std::move(attempt);
+        } else {
+            ++i;
+        }
+    }
+    return cube;
+}
+
+IC3IA::Cube IC3IA::generalizeWithUnsatCore(Cube cube, unsigned level) const {
+    assert(level > 0);
+    if (cube.size() <= 1) { return cube; }
+
+    PTRef frameFormula = getF(level - 1);
+
+    auto extractCoreLiterals = [&](std::vector<PTRef> const & literals,
+                                   vec<PTRef> const & background) -> std::vector<PTRef> {
+        SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_UNSAT_CORE);
+        for (PTRef part : background) { solver.assertProp(part); }
+        for (PTRef lit : literals) { solver.assertProp(lit); }
+
+        if (solver.check() != SMTSolver::Answer::UNSAT) { return {}; }
+
+        auto core = solver.getCoreSolver().getUnsatCore();
+        std::vector<PTRef> coreTerms;
+        coreTerms.reserve(core->getTerms().size());
+        for (PTRef t : core->getTerms()) { coreTerms.push_back(t); }
+        return coreTerms;
+    };
+
+    vec<PTRef> initBackground;
+    initBackground.push(init_);
+    auto initCore = extractCoreLiterals(cube, initBackground);
+
+    std::vector<PTRef> primedCube;
+    primedCube.reserve(cube.size());
+    for (PTRef lit : cube) { primedCube.push_back(prime(lit)); }
+
+    vec<PTRef> predBackground;
+    predBackground.push(frameFormula);
+    predBackground.push(trans_);
+    auto predCore = extractCoreLiterals(primedCube, predBackground);
+
+    Cube reduced;
+    reduced.reserve(cube.size());
+    for (std::size_t i = 0; i < cube.size(); ++i) {
+        if (std::find(initCore.begin(), initCore.end(), cube[i]) != initCore.end() ||
+            std::find(predCore.begin(), predCore.end(), primedCube[i]) != predCore.end()) {
+            reduced.push_back(cube[i]);
+        }
+    }
+
+    Cube dummy;
+    if (!initIntersects(reduced) && !hasPredecessorUnder(frameFormula, reduced, dummy)) {
+        return reduced;
+    }
+    return cube;
+}
+
+//=============================================================================
+// IC3 core — blocking loop
+//=============================================================================
+
+bool IC3IA::blockObligations(Obligation seed) {
+    using PQ = std::priority_queue<Obligation,
+                                   std::vector<Obligation>,
+                                   std::greater<Obligation>>;
+    PQ pq;
+    pq.push(std::move(seed));
+
+    while (!pq.empty()) {
+        Obligation obl = pq.top();
+        pq.pop();
+
+        {
+            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
+            solver.assertProp(getF(obl.level));
+            solver.assertProp(cubeToFla(obl.cube));
+            if (solver.check() == SMTSolver::Answer::UNSAT) { continue; }
+        }
+
+        if (obl.level == 0) {
+            if (initIntersects(obl.cube)) {
+                cexTrace_.clear();
+                Obligation const * cur = &obl;
+                while (cur) {
+                    cexTrace_.push_back(cur->cube);
+                    cur = cur->successor.get();
+                }
+                return false;
+            }
+            addClause(logic_.mkNot(cubeToFla(obl.cube)), 1u);
+            continue;
+        }
+
+        Cube cti;
+        if (hasPredecessor(obl.cube, obl.level, cti)) {
+            auto oblPtr = std::make_shared<Obligation>(obl);
+            pq.push(Obligation{std::move(cti), obl.level - 1, std::move(oblPtr)});
+            pq.push(std::move(obl));
+        } else if (initIntersects(obl.cube)) {
+            // No predecessor, but the cube is in init — push to level 0
+            // so the level-0 handler recognizes it as a real counterexample.
+            pq.push(Obligation{obl.cube, 0, obl.successor});
+        } else {
+            Cube gen = generalize(obl.cube, obl.level);
+            PTRef clause = logic_.mkNot(cubeToFla(gen));
+            addClause(clause, obl.level);
+            if (verbosity_ > 1) {
+                std::cout << "[IC3] Blocked at level " << obl.level
+                          << ", clause literals = " << gen.size() << "\n";
+            }
+        }
+    }
+    return true;
+}
+
+//=============================================================================
+// IC3 core — clause propagation
+//=============================================================================
+
+bool IC3IA::propagateClauses() {
+    for (unsigned i = 1; i < depth_; ++i) {
+        for (auto & c : clauses_) {
+            if (c.level != i) { continue; }
+            PTRef negClausePrimed = prime(logic_.mkNot(c.fla));
+            SMTSolver solver(logic_, SMTSolver::WitnessProduction::NONE);
+            solver.assertProp(getF(i));
+            solver.assertProp(trans_);
+            solver.assertProp(negClausePrimed);
+            if (solver.check() == SMTSolver::Answer::UNSAT) {
+                c.level = i + 1;
+            }
+        }
+        bool hasAtI = false;
+        for (auto const & c : clauses_) {
+            if (c.level == i) { hasAtI = true; break; }
+        }
+        if (!hasAtI) { return true; }
+    }
+    return false;
+}
+
+//=============================================================================
+// IC3 core — invariant construction
+//=============================================================================
+
+PTRef IC3IA::buildInvariant(unsigned fixpointLevel) const {
+    return getF(fixpointLevel);
+}
+
+//=============================================================================
+// IC3IA top-level solve
+//=============================================================================
+
+TransitionSystemVerificationResult IC3IA::solve(TransitionSystem const & system) {
+    concreteInit_         = system.getInit();
+    concreteTrans_        = system.getTransition();
+    concreteBad_          = system.getQuery();
+    concreteStateVars_    = system.getStateVars();
+    concreteNextStateVars_= system.getNextStateVars();
+
+    if (addInitialReset_) {
+        applyInitialReset();
+    }
+
+    predicates_.clear();
+    predLabels_.clear();
+    predLabelsNext_.clear();
+
+    initializePredicates();
+
+    if (verbosity_ > 0) {
+        std::cout << "[IC3IA] Initial predicates: " << predicates_.size() << "\n";
+    }
+
+    static constexpr unsigned maxRefinements = 1000;
+    for (unsigned iter = 0; iter < maxRefinements; ++iter) {
+        setupAbstractSystem();
+
+        auto result = runIC3();
+
+        if (result.answer == VerificationAnswer::SAFE) {
+            PTRef abstractInv = std::get<PTRef>(result.witness);
+            PTRef concreteInv = concreteInvariant(abstractInv);
+            return {VerificationAnswer::SAFE, concreteInv};
+        }
+
+        if (result.answer == VerificationAnswer::UNSAFE) {
+            std::size_t realDepth = 0;
+            if (checkAndRefine(realDepth)) {
+                return {VerificationAnswer::UNSAFE, realDepth};
+            }
+            if (verbosity_ > 0) {
+                std::cout << "[IC3IA] Spurious CEX at depth "
+                          << std::get<std::size_t>(result.witness)
+                          << "; predicates now: " << predicates_.size() << "\n";
+            }
+            continue;
+        }
+
+        return result;
+    }
+
+    return {VerificationAnswer::UNKNOWN, 0u};
+}
+
+//=============================================================================
+// IC3IA — predicate management
+//=============================================================================
+
+void IC3IA::collectVars(PTRef fla, std::vector<PTRef> & vars) const {
+    if (logic_.isVar(fla)) {
+        if (std::find(vars.begin(), vars.end(), fla) == vars.end()) {
+            vars.push_back(fla);
+        }
+        return;
+    }
+
+    Pterm const & t = logic_.getPterm(fla);
+    for (int i = 0; i < t.size(); ++i) {
+        collectVars(t[i], vars);
+    }
+}
+
+PTRef IC3IA::shiftFormulaThroughTime(PTRef fla, int steps) const {
+    if (steps == 0) { return fla; }
+
+    TimeMachine tm{logic_};
+    std::vector<PTRef> stack;
+    collectVars(fla, stack);
+
+    TermUtils::substitutions_map substitutions;
+    for (PTRef var : stack) {
+        if (tm.isVersioned(var)) {
+            substitutions[var] = tm.sendVarThroughTime(var, steps);
+        }
+    }
+
+    if (substitutions.empty()) { return fla; }
+    return TermUtils(logic_).varSubstitute(fla, substitutions);
+}
+
+void IC3IA::collectAtoms(PTRef fla, std::vector<PTRef> & atoms) const {
+    if (logic_.isTrue(fla) || logic_.isFalse(fla)) { return; }
+
+    Pterm const & t = logic_.getPterm(fla);
+
+    if (logic_.isAnd(fla) || logic_.isOr(fla)) {
+        for (int i = 0; i < t.size(); ++i) { collectAtoms(t[i], atoms); }
+        return;
+    }
+    if (logic_.isNot(fla)) {
+        collectAtoms(t[0], atoms);
+        return;
+    }
+    if (std::find(atoms.begin(), atoms.end(), fla) == atoms.end()) {
+        atoms.push_back(fla);
+    }
+}
+
+std::vector<PTRef> IC3IA::minimizeRefinementPredicateSet(std::vector<PTRef> candidates,
+                                                         std::vector<PTRef> const & unshiftedInterpolants,
+                                                         std::size_t depth) const {
+    if (candidates.size() <= 1 || unshiftedInterpolants.empty()) { return candidates; }
+
+    SMTSolver solver(logic_, SMTSolver::WitnessProduction::ONLY_UNSAT_CORE);
+    solver.assertProp(concreteInit_);
+    for (std::size_t i = 0; i < depth; ++i) {
+        solver.assertProp(atTime(concreteTrans_, static_cast<unsigned>(i)));
+    }
+    solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(depth)));
+
+    TermUtils::substitutions_map subst;
+    std::vector<PTRef> activationLiterals;
+    std::vector<PTRef> abstractionLabels;
+    std::vector<PTRef> guardedDefinitions;
+    activationLiterals.reserve(candidates.size());
+    abstractionLabels.reserve(candidates.size());
+    guardedDefinitions.reserve(candidates.size());
+
+    for (std::size_t i = 0; i < candidates.size(); ++i) {
+        std::string suffix = std::to_string(i);
+        PTRef act = logic_.mkBoolVar((".ic3ia_refpred_act_" + suffix).c_str());
+        PTRef lbl = logic_.mkBoolVar((".ic3ia_refpred_lbl_" + suffix).c_str());
+        activationLiterals.push_back(act);
+        abstractionLabels.push_back(lbl);
+        subst[candidates[i]] = lbl;
+        subst[logic_.mkNot(candidates[i])] = logic_.mkNot(lbl);
+    }
+
+    TermUtils termUtils(logic_);
+    for (std::size_t i = 0; i < unshiftedInterpolants.size(); ++i) {
+        PTRef abstractedInterpolant = termUtils.varSubstitute(unshiftedInterpolants[i], subst);
+        solver.assertProp(atTime(abstractedInterpolant, static_cast<unsigned>(i + 1)));
+    }
+
+    for (std::size_t i = 0; i < candidates.size(); ++i) {
+        vec<PTRef> eqs;
+        for (std::size_t step = 0; step < unshiftedInterpolants.size(); ++step) {
+            eqs.push(logic_.mkEq(atTime(abstractionLabels[i], static_cast<unsigned>(step + 1)),
+                                 atTime(candidates[i], static_cast<unsigned>(step + 1))));
+        }
+        PTRef definition = eqs.size() == 1 ? eqs[0] : logic_.mkAnd(eqs);
+        PTRef guarded = logic_.mkOr(logic_.mkNot(activationLiterals[i]), definition);
+        guardedDefinitions.push_back(guarded);
+        solver.assertProp(guarded);
+        solver.assertProp(activationLiterals[i]);
+    }
+
+    if (solver.check() != SMTSolver::Answer::UNSAT) { return candidates; }
+
+    auto core = solver.getCoreSolver().getUnsatCore();
+    std::vector<PTRef> kept;
+    kept.reserve(candidates.size());
+    for (std::size_t i = 0; i < candidates.size(); ++i) {
+        bool inCore = false;
+        for (PTRef t : core->getTerms()) {
+            if (t == activationLiterals[i] || t == guardedDefinitions[i]) {
+                inCore = true;
+                break;
+            }
+        }
+        if (inCore) { kept.push_back(candidates[i]); }
+    }
+
+    return kept.empty() ? candidates : kept;
+}
+
+bool IC3IA::addPredicate(PTRef pred) {
+    if (std::find(predicates_.begin(), predicates_.end(), pred) != predicates_.end()) {
+        return false;
+    }
+
+    predicates_.push_back(pred);
+
+    TimeMachine tm{logic_};
+    std::ostringstream ss;
+    ss << "ic3ia_pred_" << (predicates_.size() - 1);
+    std::string baseName = ss.str();
+
+    PTRef lCurr = tm.getVarVersionZero(baseName, logic_.getSort_bool());
+    PTRef lNext = tm.sendVarThroughTime(lCurr, 1);
+
+    predLabels_.push_back(lCurr);
+    predLabelsNext_.push_back(lNext);
+    return true;
+}
+
+void IC3IA::applyInitialReset() {
+    TimeMachine tm{logic_};
+    PTRef reset = tm.getVarVersionZero("ic3ia_reset", logic_.getSort_bool());
+    PTRef resetNext = tm.sendVarThroughTime(reset, 1);
+
+    PTRef oldInit = concreteInit_;
+    PTRef oldTrans = concreteTrans_;
+    PTRef oldBad = concreteBad_;
+
+    concreteInit_ = reset;
+    vec<PTRef> transParts;
+    transParts.push(logic_.mkNot(resetNext));
+    transParts.push(logic_.mkOr(logic_.mkNot(reset), atTime(oldInit, 1)));
+    transParts.push(logic_.mkOr(reset, oldTrans));
+    concreteTrans_ = logic_.mkAnd(transParts);
+    concreteBad_ = logic_.mkAnd(logic_.mkNot(reset), oldBad);
+    concreteStateVars_.push_back(reset);
+    concreteNextStateVars_.push_back(resetNext);
+
+    if (verbosity_ > 0) {
+        std::cout << "[IC3IA] Added initial reset state\n";
+    }
+}
+
+void IC3IA::initializePredicates() {
+    std::vector<PTRef> atoms;
+    collectAtoms(concreteInit_, atoms);
+    collectAtoms(concreteBad_,  atoms);
+
+    for (PTRef a : atoms) {
+        addPredicate(a);
+    }
+}
+
+//=============================================================================
+// IC3IA — abstract system construction
+//=============================================================================
+
+PTRef IC3IA::abstractFormula(PTRef fla) const {
+    if (logic_.isTrue(fla) || logic_.isFalse(fla)) { return fla; }
+
+    for (std::size_t i = 0; i < predicates_.size(); ++i) {
+        if (fla == predicates_[i])               { return predLabels_[i]; }
+        if (fla == logic_.mkNot(predicates_[i])) { return logic_.mkNot(predLabels_[i]); }
+    }
+
+    Pterm const & t = logic_.getPterm(fla);
+
+    if (logic_.isAnd(fla)) {
+        vec<PTRef> args;
+        for (int i = 0; i < t.size(); ++i) { args.push(abstractFormula(t[i])); }
+        return logic_.mkAnd(args);
+    }
+    if (logic_.isOr(fla)) {
+        vec<PTRef> args;
+        for (int i = 0; i < t.size(); ++i) { args.push(abstractFormula(t[i])); }
+        return logic_.mkOr(args);
+    }
+    if (logic_.isNot(fla)) {
+        return logic_.mkNot(abstractFormula(t[0]));
+    }
+
+    return fla;
+}
+
+void IC3IA::setupAbstractSystem() {
+    assert(!predicates_.empty());
+
+    vec<PTRef> labelDefParts;
+    for (std::size_t i = 0; i < predicates_.size(); ++i) {
+        labelDefParts.push(logic_.mkEq(predLabels_[i], predicates_[i]));
+    }
+    PTRef labelDefs = logic_.mkAnd(labelDefParts);
+
+    init_ = logic_.mkAnd(concreteInit_, labelDefs);
+    bad_  = logic_.mkAnd(concreteBad_,  labelDefs);
+
+    vec<PTRef> transParts;
+    transParts.push(concreteTrans_);
+    transParts.push(labelDefs);
+    for (std::size_t i = 0; i < predicates_.size(); ++i) {
+        PTRef pNext = shiftFormulaThroughTime(predicates_[i], 1);
+        transParts.push(logic_.mkEq(predLabelsNext_[i], pNext));
+    }
+    trans_ = logic_.mkAnd(transParts);
+
+    stateVars_     = predLabels_;
+    nextStateVars_ = predLabelsNext_;
+
+    resetIC3State();
+}
+
+PTRef IC3IA::concreteInvariant(PTRef abstractInv) const {
+    TermUtils::substitutions_map subst;
+    for (std::size_t i = 0; i < predicates_.size(); ++i) {
+        subst[predLabels_[i]]               = predicates_[i];
+        subst[logic_.mkNot(predLabels_[i])] = logic_.mkNot(predicates_[i]);
+    }
+    return TermUtils(logic_).varSubstitute(abstractInv, subst);
+}
+
+//=============================================================================
+// IC3IA — concrete CEGAR check
+//=============================================================================
+
+PTRef IC3IA::atTime(PTRef fla, unsigned steps) const {
+    return shiftFormulaThroughTime(fla, static_cast<int>(steps));
+}
+
+bool IC3IA::checkAndRefine(std::size_t & outDepth) {
+    std::size_t const k = cexTrace_.empty() ? depth_ : cexTrace_.size();
+    auto const refineStart = std::chrono::steady_clock::now();
+
+    if (verbosity_ > 1) {
+        std::cout << "[IC3IA] Checking concrete trace of length " << k << "\n";
+    }
+
+    SMTSolver solver(logic_, SMTSolver::WitnessProduction::MODEL_AND_INTERPOLANTS);
+    solver.getConfig().setSimplifyInterpolant(4);
+
+    auto guidedStateFormulaAt = [&](std::size_t index) {
+        if (cexTrace_.empty() || index >= cexTrace_.size()) { return logic_.getTerm_true(); }
+        return atTime(concreteInvariant(cubeToFla(cexTrace_[index])), static_cast<unsigned>(index));
+    };
+
+    vec<PTRef> initParts;
+    initParts.push(concreteInit_);
+    PTRef guideAtZero = guidedStateFormulaAt(0);
+    if (guideAtZero != logic_.getTerm_true()) { initParts.push(guideAtZero); }
+    solver.assertProp(initParts.size() == 1 ? initParts[0] : logic_.mkAnd(initParts));
+
+    for (std::size_t i = 0; i < k; ++i) {
+        vec<PTRef> transParts;
+        transParts.push(atTime(concreteTrans_, static_cast<unsigned>(i)));
+        PTRef guidedState = guidedStateFormulaAt(i + 1);
+        if (guidedState != logic_.getTerm_true()) { transParts.push(guidedState); }
+        solver.assertProp(transParts.size() == 1 ? transParts[0] : logic_.mkAnd(transParts));
+    }
+
+    solver.assertProp(atTime(concreteBad_, static_cast<unsigned>(k)));
+
+    auto const solveStart = std::chrono::steady_clock::now();
+    auto res = solver.check();
+    auto const solveEnd = std::chrono::steady_clock::now();
+    if (res == SMTSolver::Answer::SAT) {
+        outDepth = k;
+        if (verbosity_ > 1) {
+            auto solveMs = std::chrono::duration_cast<std::chrono::milliseconds>(solveEnd - solveStart).count();
+            std::cout << "[IC3IA] Concrete check SAT in " << solveMs << " ms\n";
+        }
+        return true;
+    }
+    if (res != SMTSolver::Answer::UNSAT) {
+        outDepth = k;
+        if (verbosity_ > 1) {
+            auto solveMs = std::chrono::duration_cast<std::chrono::milliseconds>(solveEnd - solveStart).count();
+            std::cout << "[IC3IA] Concrete check returned UNKNOWN in " << solveMs << " ms\n";
+        }
+        return true;
+    }
+
+    auto itpCtx = solver.getInterpolationContext();
+    vec<PTRef> interpolantsVec;
+    std::vector<ipartitions_t> pathMasks;
+    pathMasks.reserve(k);
+    for (std::size_t i = 0; i < k; ++i) {
+        ipartitions_t mask = 0;
+        for (std::size_t j = 0; j <= i + 1; ++j) {
+            opensmt::setbit(mask, static_cast<unsigned>(j));
+        }
+        pathMasks.push_back(mask);
+    }
+    auto const interpolationStart = std::chrono::steady_clock::now();
+    if (not pathMasks.empty()) {
+        if (useBinaryRefinementInterpolants_) {
+            for (ipartitions_t mask : pathMasks) {
+                std::vector<PTRef> single;
+                itpCtx->getSingleInterpolant(single, mask);
+                if (!single.empty()) { interpolantsVec.push(single.front()); }
+            }
+        } else {
+            itpCtx->getPathInterpolants(interpolantsVec, pathMasks);
+        }
+    }
+    auto const interpolationEnd = std::chrono::steady_clock::now();
+
+    std::vector<PTRef> interpolants;
+    interpolants.reserve(interpolantsVec.size());
+    for (PTRef itp : interpolantsVec) { interpolants.push_back(itp); }
+
+    std::vector<PTRef> unshiftedInterpolants;
+    unshiftedInterpolants.reserve(interpolants.size());
+    std::vector<PTRef> candidatePredicates;
+    for (std::size_t i = 0; i < interpolants.size(); ++i) {
+        PTRef unshifted = shiftFormulaThroughTime(interpolants[i], -static_cast<int>(i + 1));
+        unshiftedInterpolants.push_back(unshifted);
+        std::vector<PTRef> atoms;
+        collectAtoms(unshifted, atoms);
+        for (PTRef a : atoms) {
+            if (std::find(candidatePredicates.begin(), candidatePredicates.end(), a) == candidatePredicates.end()) {
+                candidatePredicates.push_back(a);
+            }
+        }
+    }
+
+    if (minimizeRefinementPredicates_) {
+        auto minimized = minimizeRefinementPredicateSet(candidatePredicates, unshiftedInterpolants, k);
+        if (verbosity_ > 0 && minimized.size() < candidatePredicates.size()) {
+            std::cout << "[IC3IA] Minimized refinement predicates from "
+                      << candidatePredicates.size() << " to " << minimized.size() << "\n";
+        }
+        candidatePredicates = std::move(minimized);
+    }
+
+    unsigned newPreds = 0;
+    for (PTRef pred : candidatePredicates) {
+        if (addPredicate(pred)) { ++newPreds; }
+    }
+
+    if (verbosity_ > 0) {
+        std::cout << "[IC3IA] Added " << newPreds << " new predicates\n";
+    }
+
+    if (newPreds == 0) {
+        for (PTRef itp : unshiftedInterpolants) { addPredicate(itp); }
+    }
+
+    if (verbosity_ > 1) {
+        auto solveMs = std::chrono::duration_cast<std::chrono::milliseconds>(solveEnd - solveStart).count();
+        auto interpolationMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(interpolationEnd - interpolationStart).count();
+        auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - refineStart).count();
+        std::cout << "[IC3IA] Refinement timings (ms): solve=" << solveMs
+                  << ", interpolation=" << interpolationMs
+                  << ", total=" << totalMs << "\n";
+    }
+
+    return false;
+}
+
+} // namespace golem

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -46,8 +46,6 @@ public:
 
 private:
     // --- IC3 core types ---
-
-    // A cube is a conjunction of literals over the current state variables.
     using Cube = std::vector<PTRef>;
 
     // Proof obligation: prove `cube` is not reachable at `level` steps from Init.
@@ -73,7 +71,13 @@ private:
     bool      useUnsatCoreGeneralization_{true};
     bool      minimizeRefinementPredicates_{true};
     bool      useBinaryRefinementInterpolants_{false};
-    bool      addInitialReset_{true};
+    bool      addInitialReset_{false};
+    bool      makeSimpleProperty_{false};
+
+    // When makeSimpleProperty_ is on, the original bad formula is stashed here
+    // so the SAFE invariant can be translated back (substitute p -> origBad).
+    PTRef     simplePropOrigBad_{PTRef_Undef};
+    PTRef     simplePropVar_{PTRef_Undef};
 
     // Set before calling runIC3(); setupAbstractSystem() fills these with abstract formulas.
     PTRef                init_{PTRef_Undef};
@@ -90,7 +94,6 @@ private:
 
     // --- IC3 core methods ---
 
-    void resetIC3State();
     TransitionSystemVerificationResult runIC3(bool resuming = false);
 
     void  pushFrame()          { ++depth_; }
@@ -104,7 +107,7 @@ private:
                       std::vector<PTRef> const & vars) const;
 
     bool  initIntersects(Cube const & cube) const;
-    bool  hasBadSuccessor(Cube & outCube) const;
+    bool  hasBadState(Cube & outCube) const;
     bool  hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
                                Cube & outCTI) const;
     bool  hasPredecessor(Cube const & cube, unsigned level, Cube & outCTI) const;
@@ -139,6 +142,7 @@ private:
                                                       std::size_t depth) const;
     bool addPredicate(PTRef pred);
     void applyInitialReset();
+    void applySimpleProperty();
     void initializePredicates();
 
     // --- Abstract system construction ---
@@ -154,14 +158,13 @@ private:
     PTRef concreteInvariant(PTRef abstractInv) const;
 
     // --- Persistent solvers for IC3 queries ---
-    //
-    // Both solvers are seeded once with the abstract system's constant context
-    // (init_ / trans_) in initializeAbstractSystem(). New label-definition
-    // conjuncts produced by extendAbstractSystem() are asserted incrementally,
-    // outside any push scope, so they persist across queries. Each query uses
-    // push()/pop() to scope its query-specific assertions.
     std::unique_ptr<SMTSolver> initSolver_;
     std::unique_ptr<SMTSolver> transSolver_;
+
+    // Activation literal guarding concreteTrans_ in transSolver_. Asserted true
+    // for queries that need the transition relation (predecessor, propagation),
+    // and false for queries about a single state (hasBadState).
+    PTRef transAct_{PTRef_Undef};
 
     // --- Concrete CEGAR check ---
 

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -91,7 +91,7 @@ private:
     // --- IC3 core methods ---
 
     void resetIC3State();
-    TransitionSystemVerificationResult runIC3();
+    TransitionSystemVerificationResult runIC3(bool resuming = false);
 
     void  pushFrame()          { ++depth_; }
     PTRef getF(unsigned k) const;
@@ -143,9 +143,25 @@ private:
 
     // --- Abstract system construction ---
 
+    // Number of predicates whose label-definition equalities have already been
+    // conjoined into init_/trans_/bad_. Maintained monotonically across CEGAR
+    // iterations so that extendAbstractSystem() only asserts new predicates.
+    std::size_t numAssertedPreds_{0};
+
     PTRef abstractFormula(PTRef fla) const;
-    void  setupAbstractSystem();
+    void  initializeAbstractSystem();
+    void  extendAbstractSystem();
     PTRef concreteInvariant(PTRef abstractInv) const;
+
+    // --- Persistent solvers for IC3 queries ---
+    //
+    // Both solvers are seeded once with the abstract system's constant context
+    // (init_ / trans_) in initializeAbstractSystem(). New label-definition
+    // conjuncts produced by extendAbstractSystem() are asserted incrementally,
+    // outside any push scope, so they persist across queries. Each query uses
+    // push()/pop() to scope its query-specific assertions.
+    std::unique_ptr<SMTSolver> initSolver_;
+    std::unique_ptr<SMTSolver> transSolver_;
 
     // --- Concrete CEGAR check ---
 

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef GOLEM_IC3IA_H
+#define GOLEM_IC3IA_H
+
+#include "Options.h"
+#include "TermUtils.h"
+#include "TransitionSystem.h"
+#include "TransitionSystemEngine.h"
+#include "utils/SmtSolver.h"
+
+#include <memory>
+#include <queue>
+#include <chrono>
+#include <unordered_map>
+#include <vector>
+
+namespace golem {
+
+/*
+ * IC3 with Implicit Predicate Abstraction (IC3IA).
+ *
+ * CEGAR loop:
+ *   1. Extract initial predicates from init and bad (their atomic sub-formulas).
+ *   2. Build abstract Boolean TransitionSystem:
+ *        stateVars  = { l_i (Bool) ↔ p_i(x##0) }
+ *        trans      = concreteT ∧ (l_i ↔ p_i(x##0)) ∧ (l_i' ↔ p_i(x##1))
+ *        init / bad = concrete init/bad with atoms replaced by labels
+ *   3. Run IC3 on the abstract system (via runIC3()).
+ *   4a. SAFE → translate invariant (substitute labels back to predicates) → done.
+ *   4b. UNSAFE(depth k) → concrete BMC check:
+ *        - Build Init ∧ T@0 ∧ ... ∧ T@{k-1} ∧ bad@k (using cexTrace_ cubes as guides).
+ *        - SAT  → real counterexample.
+ *        - UNSAT → extract k sequence interpolants as new predicates; restart IC3.
+ */
+class IC3IA : public TransitionSystemEngine {
+public:
+    IC3IA(Logic & logic, Options const & options);
+
+    using TransitionSystemEngine::solve;
+    TransitionSystemVerificationResult solve(TransitionSystem const & system) override;
+
+private:
+    // --- IC3 core types ---
+
+    // A cube is a conjunction of literals over the current state variables.
+    using Cube = std::vector<PTRef>;
+
+    // Proof obligation: prove `cube` is not reachable at `level` steps from Init.
+    struct Obligation {
+        Cube   cube;
+        unsigned level;
+        // unsigned traceLen;
+        std::shared_ptr<Obligation const> successor;
+
+        bool operator>(Obligation const & o) const { return level > o.level; }
+    };
+
+    // A blocking clause: ¬cube (a disjunction), valid for F[1..level].
+    struct BlockingClause {
+        PTRef    fla;
+        unsigned level;
+    };
+
+    // --- IC3 core state ---
+
+    Logic &   logic_;
+    int       verbosity_{0};
+    bool      useUnsatCoreGeneralization_{true};
+    bool      minimizeRefinementPredicates_{true};
+    bool      useBinaryRefinementInterpolants_{false};
+    bool      addInitialReset_{true};
+
+    // Set before calling runIC3(); setupAbstractSystem() fills these with abstract formulas.
+    PTRef                init_{PTRef_Undef};
+    PTRef                trans_{PTRef_Undef};
+    PTRef                bad_{PTRef_Undef};
+    std::vector<PTRef>   stateVars_;
+    std::vector<PTRef>   nextStateVars_;
+
+    unsigned             depth_{0};
+    std::vector<BlockingClause> clauses_;
+
+    // Populated when blockObligations returns false (real CEX found).
+    std::vector<Cube>    cexTrace_;
+
+    // --- IC3 core methods ---
+
+    void resetIC3State();
+    TransitionSystemVerificationResult runIC3();
+
+    void  pushFrame()          { ++depth_; }
+    PTRef getF(unsigned k) const;
+    void  addClause(PTRef clauseFla, unsigned level);
+
+    PTRef cubeToFla(Cube const & cube) const;
+    PTRef prime(PTRef fla) const;
+
+    Cube  modelToCube(std::shared_ptr<Model> const & model,
+                      std::vector<PTRef> const & vars) const;
+
+    bool  initIntersects(Cube const & cube) const;
+    bool  hasBadSuccessor(Cube & outCube) const;
+    bool  hasPredecessorUnder(PTRef frameFormula, Cube const & cube,
+                               Cube & outCTI) const;
+    bool  hasPredecessor(Cube const & cube, unsigned level, Cube & outCTI) const;
+
+    Cube  generalize(Cube cube, unsigned level) const;
+    Cube  generalizeWithUnsatCore(Cube cube, unsigned level) const;
+    bool  blockObligations(Obligation seed);
+    bool  propagateClauses();
+    PTRef buildInvariant(unsigned fixpointLevel) const;
+
+    // --- Concrete system (set at the start of solve()) ---
+
+    PTRef               concreteInit_{PTRef_Undef};
+    PTRef               concreteTrans_{PTRef_Undef};
+    PTRef               concreteBad_{PTRef_Undef};
+    std::vector<PTRef>  concreteStateVars_;
+    std::vector<PTRef>  concreteNextStateVars_;
+
+    // --- Predicate abstraction state ---
+
+    std::vector<PTRef>  predicates_;      // p_i(x##0) — concrete atoms
+    std::vector<PTRef>  predLabels_;      // l_i##0    — Boolean current-state label
+    std::vector<PTRef>  predLabelsNext_;  // l_i##1    — Boolean next-state label
+
+    // --- Predicate management ---
+
+    void collectVars(PTRef fla, std::vector<PTRef> & vars) const;
+    PTRef shiftFormulaThroughTime(PTRef fla, int steps) const;
+    void collectAtoms(PTRef fla, std::vector<PTRef> & atoms) const;
+    std::vector<PTRef> minimizeRefinementPredicateSet(std::vector<PTRef> candidates,
+                                                      std::vector<PTRef> const & unshiftedInterpolants,
+                                                      std::size_t depth) const;
+    bool addPredicate(PTRef pred);
+    void applyInitialReset();
+    void initializePredicates();
+
+    // --- Abstract system construction ---
+
+    PTRef abstractFormula(PTRef fla) const;
+    void  setupAbstractSystem();
+    PTRef concreteInvariant(PTRef abstractInv) const;
+
+    // --- Concrete CEGAR check ---
+
+    bool checkAndRefine(std::size_t & outDepth);
+    PTRef atTime(PTRef fla, unsigned steps) const;
+};
+
+} // namespace golem
+
+#endif // GOLEM_IC3IA_H

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -70,12 +70,6 @@ private:
     int       verbosity_{0};
     bool      useUnsatCoreGeneralization_{true};
     bool      addInitialReset_{false};
-    bool      makeSimpleProperty_{false};
-
-    // When makeSimpleProperty_ is on, the original bad formula is stashed here
-    // so the SAFE invariant can be translated back (substitute p -> origBad).
-    PTRef     simplePropOrigBad_{PTRef_Undef};
-    PTRef     simplePropVar_{PTRef_Undef};
 
     // Set before calling runIC3(); setupAbstractSystem() fills these with abstract formulas.
     PTRef                init_{PTRef_Undef};
@@ -140,7 +134,6 @@ private:
                                                       std::size_t depth) const;
     bool addPredicate(PTRef pred);
     void applyInitialReset();
-    void applySimpleProperty();
     void initializePredicates();
 
     // --- Abstract system construction ---

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -69,8 +69,6 @@ private:
     Logic &   logic_;
     int       verbosity_{0};
     bool      useUnsatCoreGeneralization_{true};
-    bool      minimizeRefinementPredicates_{true};
-    bool      useBinaryRefinementInterpolants_{false};
     bool      addInitialReset_{false};
     bool      makeSimpleProperty_{false};
 

--- a/src/engine/IC3IA.h
+++ b/src/engine/IC3IA.h
@@ -157,13 +157,13 @@ private:
     void  extendAbstractSystem();
     PTRef concreteInvariant(PTRef abstractInv) const;
 
-    // --- Persistent solvers for IC3 queries ---
-    std::unique_ptr<SMTSolver> initSolver_;
-    std::unique_ptr<SMTSolver> transSolver_;
-
-    // Activation literal guarding concreteTrans_ in transSolver_. Asserted true
-    // for queries that need the transition relation (predecessor, propagation),
-    // and false for queries about a single state (hasBadState).
+    // --- Persistent solver for IC3 queries ---
+    // One incremental solver carries concreteInit_ / concreteTrans_ (each
+    // guarded by an activation literal) plus the accumulated label-defs and
+    // next-label-defs. Each query toggles initAct_ / transAct_ to select
+    // which parts are active.
+    std::unique_ptr<SMTSolver> solver_;
+    PTRef initAct_{PTRef_Undef};
     PTRef transAct_{PTRef_Undef};
 
     // --- Concrete CEGAR check ---

--- a/src/utils/SmtSolver.cc
+++ b/src/utils/SmtSolver.cc
@@ -11,9 +11,11 @@ SMTSolver::SMTSolver(Logic & logic, WitnessProduction setup) {
     bool produceModel = setup == WitnessProduction::ONLY_MODEL || setup == WitnessProduction::MODEL_AND_INTERPOLANTS;
     bool produceInterpolants =
         setup == WitnessProduction::ONLY_INTERPOLANTS || setup == WitnessProduction::MODEL_AND_INTERPOLANTS;
+    bool produceUnsatCores = setup == WitnessProduction::ONLY_UNSAT_CORE;
     const char * msg = "ok";
     this->config.setOption(SMTConfig::o_produce_models, SMTOption(produceModel), msg);
     this->config.setOption(SMTConfig::o_produce_inter, SMTOption(produceInterpolants), msg);
+    this->config.setOption(SMTConfig::o_produce_unsat_cores, SMTOption(produceUnsatCores), msg);
     solver = std::make_unique<MainSolver>(logic, config, "");
 }
 

--- a/src/utils/SmtSolver.h
+++ b/src/utils/SmtSolver.h
@@ -20,7 +20,7 @@ class SMTSolver {
 public:
     enum class Answer { SAT, UNSAT, UNKNOWN, ERROR };
 
-    enum class WitnessProduction { NONE, ONLY_MODEL, ONLY_INTERPOLANTS, MODEL_AND_INTERPOLANTS };
+    enum class WitnessProduction { NONE, ONLY_MODEL, ONLY_INTERPOLANTS, MODEL_AND_INTERPOLANTS, ONLY_UNSAT_CORE };
 
     // Default setup in OpenSMT is currently to produce models, but not interpolants
     explicit SMTSolver(Logic & logic, WitnessProduction setup = WitnessProduction::ONLY_MODEL);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(GolemTest
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_TRL.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_TransformationUtils.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_Transformers.cc"
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_IC3.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_IMC.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_PDKIND.cc"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/test_PredicateAbstraction.cc"

--- a/test/test_IC3.cc
+++ b/test/test_IC3.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "TestTemplate.h"
+#include "engine/IC3IA.h"
+
+// ===========================================================================
+// IC3 tests (QF_LIA system — the CHC pipeline converts to a TransitionSystem
+//            whose state vars happen to be versioned integer vars, but IC3
+//            works on any domain where model evaluation returns bool values.
+//            For pure Boolean systems IC3 is sound and complete.
+//            For QF_LIA we test IC3IA instead.)
+// ===========================================================================
+
+class IC3LIATest : public LIAEngineTest {};
+
+TEST_F(IC3LIATest, test_IC3IA_simple_unsafe) {
+    Options options;
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next    = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{
+        { // x' = 0 => s1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        { // s1(x) and x' = x + 1 => s1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))},
+                    {UninterpretedPredicate{current}}}
+        },
+        { // s1(x) and x > 1 => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGt(x, one)}, {UninterpretedPredicate{current}}}
+        }
+    };
+    IC3IA engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+}
+
+TEST_F(IC3LIATest, test_IC3IA_simple_safe) {
+    Options options;
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next    = instantiatePredicate(s1, {xp});
+    std::vector<ChClause> clauses{
+        { // x' = 0 => s1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        { // s1(x) and x' = x + 1 => s1(x')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkPlus(x, one))},
+                    {UninterpretedPredicate{current}}}
+        },
+        { // s1(x) and x < 0 => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkLt(x, zero)}, {UninterpretedPredicate{current}}}
+        }
+    };
+    IC3IA engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+}
+
+TEST_F(IC3LIATest, test_IC3IA_two_vars_safe) {
+    Options options;
+    SymRef s1 = mkPredicateSymbol("s1", {intSort(), intSort()});
+    PTRef current = instantiatePredicate(s1, {x, y});
+    PTRef next    = instantiatePredicate(s1, {xp, yp});
+    std::vector<ChClause> clauses{
+        { // x' = 0 and y' = 0 => s1(x',y')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, zero), logic->mkEq(yp, zero))}, {}}
+        },
+        { // s1(x,y) and x' = x+1 and y' = y+1 => s1(x',y')
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkAnd(logic->mkEq(xp, logic->mkPlus(x, one)),
+                                  logic->mkEq(yp, logic->mkPlus(y, one)))},
+                    {UninterpretedPredicate{current}}}
+        },
+        { // s1(x,y) and x != y => false
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkNot(logic->mkEq(x, y))}, {UninterpretedPredicate{current}}}
+        }
+    };
+    IC3IA engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+}
+
+TEST_F(IC3LIATest, test_IC3IA_init_violates_property) {
+    Options options;
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next    = instantiatePredicate(s1, {xp});
+    // Init: x = 5; Trans: x' = x; Bad: x >= 5
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, logic->mkIntConst(5))}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, x)}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGeq(x, logic->mkIntConst(5))},
+                    {UninterpretedPredicate{current}}}
+        }
+    };
+    IC3IA engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+}

--- a/test/test_IC3.cc
+++ b/test/test_IC3.cc
@@ -19,6 +19,8 @@ class IC3LIATest : public LIAEngineTest {};
 
 TEST_F(IC3LIATest, test_IC3IA_simple_unsafe) {
     Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
     PTRef current = instantiatePredicate(s1, {x});
     PTRef next    = instantiatePredicate(s1, {xp});
@@ -38,11 +40,13 @@ TEST_F(IC3LIATest, test_IC3IA_simple_unsafe) {
         }
     };
     IC3IA engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }
 
 TEST_F(IC3LIATest, test_IC3IA_simple_safe) {
     Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
     PTRef current = instantiatePredicate(s1, {x});
     PTRef next    = instantiatePredicate(s1, {xp});
@@ -62,11 +66,13 @@ TEST_F(IC3LIATest, test_IC3IA_simple_safe) {
         }
     };
     IC3IA engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(IC3LIATest, test_IC3IA_two_vars_safe) {
     Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort(), intSort()});
     PTRef current = instantiatePredicate(s1, {x, y});
     PTRef next    = instantiatePredicate(s1, {xp, yp});
@@ -87,11 +93,13 @@ TEST_F(IC3LIATest, test_IC3IA_two_vars_safe) {
         }
     };
     IC3IA engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::SAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
 TEST_F(IC3LIATest, test_IC3IA_init_violates_property) {
     Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
     SymRef s1 = mkPredicateSymbol("s1", {intSort()});
     PTRef current = instantiatePredicate(s1, {x});
     PTRef next    = instantiatePredicate(s1, {xp});
@@ -112,5 +120,5 @@ TEST_F(IC3LIATest, test_IC3IA_init_violates_property) {
         }
     };
     IC3IA engine(*logic, options);
-    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, false);
+    solveSystem(clauses, engine, VerificationAnswer::UNSAFE, true);
 }

--- a/test/test_IC3.cc
+++ b/test/test_IC3.cc
@@ -96,6 +96,33 @@ TEST_F(IC3LIATest, test_IC3IA_two_vars_safe) {
     solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
 }
 
+TEST_F(IC3LIATest, test_IC3IA_single_feasible_state) {
+    Options options;
+    options.addOption(Options::LOGIC, "QF_LIA");
+    options.addOption(Options::COMPUTE_WITNESS, "true");
+    SymRef s1 = mkPredicateSymbol("s1", {intSort()});
+    PTRef current = instantiatePredicate(s1, {x});
+    PTRef next    = instantiatePredicate(s1, {xp});
+    // Init: x = 0; Trans: x' = 0; Bad: x > 0
+    std::vector<ChClause> clauses{
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{next}},
+            ChcBody{{logic->mkEq(xp, zero)}, {UninterpretedPredicate{current}}}
+        },
+        {
+            ChcHead{UninterpretedPredicate{logic->getTerm_false()}},
+            ChcBody{{logic->mkGt(x, zero)},
+                    {UninterpretedPredicate{current}}}
+        }
+    };
+    IC3IA engine(*logic, options);
+    solveSystem(clauses, engine, VerificationAnswer::SAFE, true);
+}
+
 TEST_F(IC3LIATest, test_IC3IA_init_violates_property) {
     Options options;
     options.addOption(Options::LOGIC, "QF_LIA");


### PR DESCRIPTION
## Summary

This PR introduces [IC3IA](https://es-static.fbk.eu/people/griggio/ic3ia/index.html) as an engine for transition systems in Golem.

This is a CEGAR-based approach for safety verification: predicates are mined from the initial formula and the target safety properties → predicate labels are introduced → IC3 runs on abstract system → if safe, done; if unsafe, spurious check and new predicates might be added via interpolation → loop restarts.

Includes simple options for different generalization in IC3, and refinement strategies.

Co-authored with Claude Sonnet 4.6, mainly to navigate Golem and OpenSMT API.

## Usage

```bash
golem -l QF_LIA -e ic3ia input.smt2